### PR TITLE
CTA tiles and Countdown

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -12,7 +12,6 @@ body {
 
 body .xcond {
   font-family: "ff-good-web-pro-extra-conden", sans-serif;
-  @apply italic;
 }
 
 .countdown-tile {
@@ -20,7 +19,7 @@ body .xcond {
 }
 
 .countdown-text {
-  @apply text-6xl font-black;
+  @apply text-9xl text-roses-red font-extrabold;
 }
 
 .countdown-title {

--- a/components/Countdown.vue
+++ b/components/Countdown.vue
@@ -1,36 +1,37 @@
 <template>
-  <div class="grid grid-cols-2 sm:grid-cols-4 gap-6">
-    <div class="flex flex-col items-center gap-4">
-      <div class="countdown-tile">
-        <p class="countdown-text">
-          {{ time.days }}
+  <div
+    class="flex flex-col lg:flex-row gap-2 sm:gap-10 justify-center items-center lg:items-start"
+  >
+    <div class="flex gap-0 sm:gap-10">
+      <div class="flex flex-col items-center justify-center gap-4 w-32">
+        <p class="countdown-text xcond">
+          {{ formatTime(time.days) }}
         </p>
+        <p class="font-semibold">Days</p>
       </div>
-      <p class="countdown-title">DAYS</p>
+      <p class="text-9xl leading-[0.75]">:</p>
+      <div class="flex flex-col items-center justify-center gap-4 w-32">
+        <p class="countdown-text xcond">
+          {{ formatTime(time.hours) }}
+        </p>
+        <p class="font-semibold">Hours</p>
+      </div>
     </div>
-    <div class="flex flex-col items-center gap-4">
-      <div class="countdown-tile">
-        <p class="countdown-text">
-          {{ time.hours }}
+    <p class="hidden lg:flex text-9xl leading-[0.75]">:</p>
+    <div class="flex gap-0 sm:gap-10">
+      <div class="flex flex-col items-center justify-center gap-4 w-32">
+        <p class="countdown-text xcond">
+          {{ formatTime(time.minutes) }}
         </p>
+        <p class="font-semibold">Minutes</p>
       </div>
-      <p class="countdown-title">HOURS</p>
-    </div>
-    <div class="flex flex-col items-center gap-4">
-      <div class="countdown-tile">
-        <p class="countdown-text">
-          {{ time.minutes }}
+      <p class="text-9xl leading-[0.75]">:</p>
+      <div class="flex flex-col items-center justify-center gap-4 w-32">
+        <p class="countdown-text xcond">
+          {{ formatTime(time.seconds) }}
         </p>
+        <p class="font-semibold">Seconds</p>
       </div>
-      <p class="countdown-title">MINUTES</p>
-    </div>
-    <div class="flex flex-col items-center gap-4">
-      <div class="countdown-tile">
-        <p class="countdown-text">
-          {{ time.seconds }}
-        </p>
-      </div>
-      <p class="countdown-title">SECONDS</p>
     </div>
   </div>
 </template>
@@ -79,6 +80,9 @@ export default {
           this.time.seconds = 0;
         }
       }, 1000);
+    },
+    formatTime(value) {
+      return value < 10 ? "0" + value : value;
     },
   },
 };

--- a/components/CtaTiles.vue
+++ b/components/CtaTiles.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="bg-light-gray w-full">
+    <div
+      class="container mx-auto py-28 flex flex-col gap-10 justify-center items-center"
+    >
+      <h2 class="font-bold xcond text-5xl text-center">
+        A WEEKEND OF SPORTING RIVALRY
+      </h2>
+      <div class="grid sm:grid-cols-2 lg:flex lg:flex-row text-white gap-4">
+        <a
+          href="/fixtures"
+          class="relative flex flex-col justify-end overflow-hidden"
+        >
+          <div
+            class="absolute flex w-full justify-between items-center px-6 pb-8 z-10"
+          >
+            <h3 class="font-bold xcond text-4xl">FIXTURES</h3>
+            <i class="fa-solid fa-arrow-right text-roses-red text-2xl"></i>
+          </div>
+          <img
+            class="hover:scale-105 transition-all"
+            src="https://assets-cdn.sums.su/YU/website/img/Roses/Fixtures_Tile.png"
+            alt="Fixtures"
+          />
+        </a>
+        <a class="relative flex flex-col justify-end overflow-hidden">
+          <div
+            class="absolute flex w-full justify-between items-center px-6 pb-8 z-10"
+          >
+            <h3 class="font-bold xcond text-4xl">GET INVOLVED</h3>
+            <i class="fa-solid fa-arrow-right text-roses-red text-2xl"></i>
+          </div>
+          <img
+            class="hover:scale-105 transition-all"
+            src="https://assets-cdn.sums.su/YU/website/img/Roses/Get_Involved_Tile.png"
+            alt="Get Involved"
+          />
+        </a>
+        <a class="relative flex flex-col justify-end overflow-hidden">
+          <div
+            class="absolute flex w-full justify-between items-center px-6 pb-8 z-10"
+          >
+            <h3 class="font-bold xcond text-4xl">FOOD & DRINK</h3>
+            <i class="fa-solid fa-arrow-right text-roses-red text-2xl"></i>
+          </div>
+          <img
+            class="hover:scale-105 transition-all"
+            src="https://assets-cdn.sums.su/YU/website/img/Roses/Food_Drink_Tile.png"
+            alt="Food & Drink"
+          />
+        </a>
+        <a class="relative flex flex-col justify-end overflow-hidden">
+          <div
+            class="absolute flex w-full justify-between items-center px-6 pb-8 z-10"
+          >
+            <h3 class="font-bold xcond text-4xl">SHOP</h3>
+            <i class="fa-solid fa-arrow-right text-roses-red text-2xl"></i>
+          </div>
+          <img
+            class="hover:scale-105 transition-all"
+            src="https://assets-cdn.sums.su/YU/website/img/Roses/Shop_Tile.png"
+            alt="Shop"
+          />
+        </a>
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/HeroBanner.vue
+++ b/components/HeroBanner.vue
@@ -6,7 +6,7 @@
     <div class="container mx-auto flex justify-between h-full">
       <div class="flex flex-col lg:max-w-[40%] gap-6 text-white justify-center">
         <p class="text-lg hidden lg:block">{{ subTitle }}</p>
-        <h1 class="text-7xl lg:text-8xl font-bold xcond">{{ title }}</h1>
+        <h1 class="text-7xl lg:text-8xl font-bold xcond italic">{{ title }}</h1>
         <RosesButton
           v-if="buttonHref && buttonTitle"
           :href="buttonHref"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -11,15 +11,28 @@
     <div class="container mx-auto">
       <div class="flex flex-col text-4xl py-10">Test index</div>
     </div>
+    <div class="flex flex-col items-center justify-center gap-14 py-28">
+      <div class="container mx-auto">
+        <h2 class="font-bold xcond text-5xl text-center">
+          COUNTDOWN TO ROSES 2025
+        </h2>
+      </div>
+      <RosesCountdown date="2025-05-02T20:00:00" />
+    </div>
+    <CtaTiles />
   </div>
 </template>
 
 <script>
 import HeroBanner from "~/components/HeroBanner.vue";
+import RosesCountdown from "~/components/Countdown.vue";
+import CtaTiles from "~/components/CtaTiles.vue";
 export default {
   name: "IndexPage",
   components: {
     HeroBanner,
+    CtaTiles,
+    RosesCountdown,
   },
 };
 </script>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,7 @@ export default {
         "primary-red": "#E74C3C",
         "roses-dark": "#231f20",
         "roses-red": "#ea3723",
+        "light-gray": "#f8f8f8",
       },
       screens: {
         // This is just to allow more breakpoints smaller than the default, can be changed to something else


### PR DESCRIPTION
### Description

This pull request includes several changes to enhance the visual design and functionality of the countdown and call-to-action (CTA) components on the website. The changes involve updates to CSS styles, Vue components, and the main index page. This also closes: https://linear.app/yorksu/issue/ROS-67/countdown

### Visual Design Enhancements:

* [`assets/css/main.css`](diffhunk://#diff-b15932692c619f9a334ecb156ac167557c3af214a8a3df8990c09232ac8a5baaL15-R22): Updated the `countdown-text` class to use a larger font size and a new color. Removed the italic style from the `.xcond` class.
* [`components/HeroBanner.vue`](diffhunk://#diff-f7561abdbd8b07c0e01990c282131c9d83bcefd9bab9383f28edda92f95bb765L9-R9): Added italic styling to the `title` in the hero banner to improve visual emphasis.

### Countdown Component Improvements:

* [`components/Countdown.vue`](diffhunk://#diff-11c516afc67293a67eb69b726bba8f36abb0fccbef246597a67c7f19247db258L2-L33): Refactored the countdown component layout to be more responsive and visually appealing. Added a `formatTime` method to ensure time values are always two digits. [[1]](diffhunk://#diff-11c516afc67293a67eb69b726bba8f36abb0fccbef246597a67c7f19247db258L2-L33) [[2]](diffhunk://#diff-11c516afc67293a67eb69b726bba8f36abb0fccbef246597a67c7f19247db258R84-R86)

### New Call-to-Action Tiles:

* [`components/CtaTiles.vue`](diffhunk://#diff-9060a3c4c017c0f43fef18753c09c767bc468fd7ebeb53b3638622802f38c745R1-R68): Created a new CTA tiles component to promote key sections like fixtures, getting involved, food & drink, and the shop.

### Main Index Page Updates:

* [`pages/index.vue`](diffhunk://#diff-02281a80fab758cb4e8e8359b222a8a5afeaa9d5a7ba858f15d852f1f8969ecfR14-R35): Integrated the new countdown and CTA tiles components into the main index page, adding a countdown to the Roses 2025 event and promoting key sections with visually appealing tiles.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
