### PR TITLE
Fixtures, fixture tile, day filters, and search box

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -29,3 +29,27 @@ body .xcond {
 .footer a {
   @apply hover:underline;
 }
+
+.fixtureTile {
+  @apply border-b border-slate-300 py-5 justify-between;
+}
+
+.scoreTile {
+  @apply px-1 aspect-square flex justify-center items-center;
+}
+
+.scoreTileYork {
+  @apply border border-black;
+}
+
+.scoreTileLancaster {
+  @apply bg-roses-red text-white;
+}
+
+.fixtureTime {
+  @apply lg:pl-24 lg:pr-16 lg:border-r border-slate-300;
+}
+
+.fixtureDetails {
+  @apply lg:pl-16;
+}

--- a/components/DayFilters.vue
+++ b/components/DayFilters.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="flex flex-col gap-6 lg:flex-row">
+    <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-5 gap-6">
+      <RosesButton title="Before" />
+      <RosesButton title="Friday" />
+      <RosesButton title="Saturday" />
+      <RosesButton title="Sunday" />
+    </div>
+    <div class="grid grid-cols-2 sm:grid-cols-4 lg:flex gap-6">
+      <RosesButton title="Sports" />
+    </div>
+  </div>
+</template>
+
+<script>
+import RosesButton from "~/components/button.vue";
+export default {
+  name: "DayFilters",
+  components: {
+    RosesButton,
+  },
+};
+</script>

--- a/components/DayFilters.vue
+++ b/components/DayFilters.vue
@@ -7,7 +7,7 @@
       <RosesButton title="Sunday" />
     </div>
     <div class="grid grid-cols-2 sm:grid-cols-4 lg:flex gap-6">
-      <RosesButton title="Sports" />
+      <RosesButton title="Activities" />
     </div>
   </div>
 </template>

--- a/components/FixtureSearch.vue
+++ b/components/FixtureSearch.vue
@@ -1,0 +1,12 @@
+<template>
+  <div class="relative w-full flex items-center">
+    <input
+      type="text"
+      class="w-full bg-light-gray pl-10 pr-6 lg:px-10 py-2 rounded-lg border placeholder-slate-500 border-slate-300"
+      placeholder="Search for a fixture or activity..."
+    />
+    <div class="absolute left-4">
+      <i class="fa-solid fa-magnifying-glass text-slate-500"></i>
+    </div>
+  </div>
+</template>

--- a/components/FixtureTile.vue
+++ b/components/FixtureTile.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="w-full flex flex-col gap-2 lg:gap-0 lg:flex-row fixtureTile">
+    <div class="fixtureTime">
+      <p class="font-semibold text-xl lg:text-2xl">{{ formattedTime }}</p>
+    </div>
+    <div class="flex flex-col gap-2 lg:gap-0 flex-grow fixtureDetails">
+      <div class="flex flex-wrap gap-2 text-xl lg:text-2xl">
+        <h3 class="font-bold">{{ fixture.sport }}</h3>
+        <p class="">{{ fixture.team }}</p>
+      </div>
+      <div class="flex justify-between">
+        <p>{{ fixture.location }}</p>
+        <p
+          v-if="fixture.pointsAvailable"
+          class="block lg:hidden whitespace-nowrap"
+        >
+          {{ fixture.pointsAvailable }} POINTS
+        </p>
+      </div>
+    </div>
+    <div class="flex flex-col gap-2">
+      <div
+        class="flex items-center justify-start sm:justify-end gap-6 sm:gap-8"
+      >
+        <div class="flex gap-4 items-center">
+          <p class="font-semibold text-lg lg:text-2xl">YORK</p>
+          <div class="scoreTile scoreTileYork">
+            <p class="text-xl lg:text-2xl">
+              {{ formatScore(fixture.YorkScore) }}
+            </p>
+          </div>
+        </div>
+        <div class="flex gap-4 items-center">
+          <p class="font-semibold text-lg lg:text-2xl">LANCASTER</p>
+          <div class="scoreTile scoreTileLancaster">
+            <p class="text-xl lg:text-2xl">
+              {{ formatScore(fixture.LancasterScore) }}
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="hidden lg:flex items-center justify-end">
+        <p v-if="fixture.pointsAvailable" class="whitespace-nowrap">
+          {{ fixture.pointsAvailable }} POINTS
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "FixtureTile",
+  props: {
+    fixture: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  computed: {
+    formattedTime() {
+      const date = new Date(this.fixture.date);
+      const hours = date.getHours().toString().padStart(2, "0");
+      const minutes = date.getMinutes().toString().padStart(2, "0");
+      return `${hours}:${minutes}`;
+    },
+  },
+  methods: {
+    formatScore(score) {
+      return score.toString().padStart(2, "0");
+    },
+  },
+};
+</script>

--- a/components/HeroBanner.vue
+++ b/components/HeroBanner.vue
@@ -7,11 +7,13 @@
       <div class="flex flex-col lg:max-w-[40%] gap-6 text-white justify-center">
         <p class="text-lg hidden lg:block">{{ subTitle }}</p>
         <h1 class="text-7xl lg:text-8xl font-bold xcond italic">{{ title }}</h1>
-        <RosesButton
-          v-if="buttonHref && buttonTitle"
-          :href="buttonHref"
-          :title="buttonTitle"
-        />
+        <div>
+          <RosesButton
+            v-if="buttonHref && buttonTitle"
+            :href="buttonHref"
+            :title="buttonTitle"
+          />
+        </div>
       </div>
       <div v-if="subImage" class="hidden lg:flex">
         <img :src="subImage" class="object-cover w-full h-full" alt="" />

--- a/components/button.vue
+++ b/components/button.vue
@@ -1,7 +1,7 @@
 <template>
   <a
     :href="href"
-    class="bg-roses-red text-white px-10 py-2 rounded-full w-fit"
+    class="bg-roses-red text-white px-6 lg:px-10 py-2 rounded-full text-center"
     >{{ title }}</a
   >
 </template>

--- a/pages/fixtures.vue
+++ b/pages/fixtures.vue
@@ -1,0 +1,64 @@
+<template>
+  <div>
+    <HeroBanner
+      title="FIXTURES"
+      image="https://assets-cdn.sums.su/YU/website/img/Roses/Hero_Banner_Fixtures.png"
+    />
+    <div class="container mx-auto py-28">
+      <div class="pb-12 lg:pb-28 flex flex-col gap-8">
+        <DayFilters />
+        <FixtureSearch />
+      </div>
+      <FixtureTile
+        v-for="fixture in fixtures"
+        :key="fixture.id"
+        :fixture="fixture"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import HeroBanner from "~/components/HeroBanner.vue";
+import FixtureTile from "~/components/FixtureTile.vue";
+import DayFilters from "~/components/DayFilters.vue";
+import FixtureSearch from "~/components/FixtureSearch.vue";
+export default {
+  name: "FixturesPage",
+  components: {
+    HeroBanner,
+    FixtureTile,
+    DayFilters,
+    FixtureSearch,
+  },
+  props: {
+    fixtures: {
+      type: Array,
+      default() {
+        return [
+          {
+            id: 1,
+            date: "2025-05-02T15:00:00",
+            sport: "Football",
+            team: "Men's 1st",
+            location: "22 Acres",
+            pointsAvailable: 2,
+            YorkScore: 0,
+            LancasterScore: 0,
+          },
+          {
+            id: 2,
+            date: "2025-05-02T15:00:00",
+            sport: "Equestrian",
+            team: "2nd team",
+            location: "Harrogate Riding Centre",
+            pointsAvailable: 2,
+            YorkScore: 0,
+            LancasterScore: 0,
+          },
+        ];
+      },
+    },
+  },
+};
+</script>


### PR DESCRIPTION
### Description

This PR includes the creation of the fixtures page, with the fixtures tile component, the day filters ( closing https://linear.app/yorksu/issue/ROS-73/day-filters-ui ), and the search box. These are purely UI features at the moment, and the functionality will be added once the backend is ready.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
