### PR TITLE
Initial work on day filters and loading state

### DIFF
--- a/components/DayFilters.vue
+++ b/components/DayFilters.vue
@@ -55,6 +55,12 @@ export default {
   components: {
     RosesButton,
   },
+  props: {
+    searchTerm: {
+      type: String,
+      default: "",
+    },
+  },
   emits: ["selectDay"],
   data() {
     return {
@@ -76,6 +82,16 @@ export default {
         endsAt: "2025-05-05T00:00:00Z",
       },
     };
+  },
+  watch: {
+    searchTerm() {
+      if (this.searchTerm === "") {
+        this.setDefaultDay();
+      } else {
+        this.selectedDay = null;
+        this.$emit("selectDay", null);
+      }
+    },
   },
   mounted() {
     this.setDefaultDay();

--- a/components/DayFilters.vue
+++ b/components/DayFilters.vue
@@ -1,10 +1,46 @@
 <template>
   <div class="flex flex-col gap-6 lg:flex-row">
     <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-5 gap-6">
-      <RosesButton title="Before" />
-      <RosesButton title="Friday" />
-      <RosesButton title="Saturday" />
-      <RosesButton title="Sunday" />
+      <button
+        role="button"
+        :class="[
+          'bg-roses-red text-white px-6 lg:px-10 py-2 rounded-full text-center hover:cursor-pointer',
+          { '!bg-black !text-white': selectedDay === before },
+        ]"
+        @click="selectDay(before)"
+      >
+        Before
+      </button>
+      <button
+        role="button"
+        :class="[
+          'bg-roses-red text-white px-6 lg:px-10 py-2 rounded-full text-center hover:cursor-pointer',
+          { '!bg-black !text-white': selectedDay === friday },
+        ]"
+        @click="selectDay(friday)"
+      >
+        Friday
+      </button>
+      <button
+        role="button"
+        :class="[
+          'bg-roses-red text-white px-6 lg:px-10 py-2 rounded-full text-center hover:cursor-pointer',
+          { '!bg-black !text-white': selectedDay === saturday },
+        ]"
+        @click="selectDay(saturday)"
+      >
+        Saturday
+      </button>
+      <button
+        role="button"
+        :class="[
+          'bg-roses-red text-white px-6 lg:px-10 py-2 rounded-full text-center hover:cursor-pointer',
+          { '!bg-black !text-white': selectedDay === sunday },
+        ]"
+        @click="selectDay(sunday)"
+      >
+        Sunday
+      </button>
     </div>
     <div class="grid grid-cols-2 sm:grid-cols-4 lg:flex gap-6">
       <RosesButton title="Activities" />
@@ -18,6 +54,56 @@ export default {
   name: "DayFilters",
   components: {
     RosesButton,
+  },
+  emits: ["selectDay"],
+  data() {
+    return {
+      selectedDay: null,
+      before: {
+        startsAt: "2025-03-05T00:00:00Z",
+        endsAt: "2025-05-02T00:00:00Z",
+      },
+      friday: {
+        startsAt: "2025-05-02T00:00:00Z",
+        endsAt: "2025-05-03T00:00:00Z",
+      },
+      saturday: {
+        startsAt: "2025-05-03T00:00:00Z",
+        endsAt: "2025-05-04T00:00:00Z",
+      },
+      sunday: {
+        startsAt: "2025-05-04T00:00:00Z",
+        endsAt: "2025-05-05T00:00:00Z",
+      },
+    };
+  },
+  mounted() {
+    this.setDefaultDay();
+  },
+  methods: {
+    setDefaultDay() {
+      const currentDate = new Date();
+      const beforeDate = new Date(this.before.endsAt);
+      const fridayDate = new Date(this.friday.endsAt);
+      const saturdayDate = new Date(this.saturday.endsAt);
+      const sundayDate = new Date(this.sunday.endsAt);
+      if (currentDate < beforeDate) {
+        this.selectedDay = this.before;
+      } else if (currentDate < fridayDate) {
+        this.selectedDay = this.friday;
+      } else if (currentDate < saturdayDate) {
+        this.selectedDay = this.saturday;
+      } else if (currentDate < sundayDate) {
+        this.selectedDay = this.sunday;
+      } else {
+        this.selectedDay = this.friday;
+      }
+      this.$emit("selectDay", this.selectedDay);
+    },
+    selectDay(day) {
+      this.selectedDay = day;
+      this.$emit("selectDay", day);
+    },
   },
 };
 </script>

--- a/components/FixtureSearch.vue
+++ b/components/FixtureSearch.vue
@@ -1,12 +1,37 @@
 <template>
-  <div class="relative w-full flex items-center">
-    <input
-      type="text"
-      class="w-full bg-light-gray pl-10 pr-6 lg:px-10 py-2 rounded-lg border placeholder-slate-500 border-slate-300"
-      placeholder="Search for a fixture or activity..."
-    />
-    <div class="absolute left-4">
-      <i class="fa-solid fa-magnifying-glass text-slate-500"></i>
-    </div>
+  <div class="w-full flex items-center h-10.5">
+    <form :action="search" class="w-full flex items-center h-10.5">
+      <input
+        id="searchInput"
+        type="text"
+        class="w-full bg-light-gray px-6 py-2 rounded-s-lg border placeholder-slate-500 border-slate-300"
+        placeholder="Search for a fixture or activity..."
+      />
+      <button
+        aria-label="Search"
+        class="bg-roses-red h-full flex items-center justify-center w-10 rounded-e-lg hover:cursor-pointer"
+        @click.prevent="search"
+      >
+        <i class="fa-solid fa-magnifying-glass text-white"></i>
+      </button>
+    </form>
   </div>
 </template>
+
+<script>
+export default {
+  name: "FixtureSearch",
+  emits: ["search"],
+  data() {
+    return {
+      searchTerm: "",
+    };
+  },
+  methods: {
+    search() {
+      this.searchTerm = document.getElementById("searchInput").value;
+      this.$emit("search", this.searchTerm);
+    },
+  },
+};
+</script>

--- a/components/FixtureTile.vue
+++ b/components/FixtureTile.vue
@@ -1,6 +1,6 @@
 <template>
   <a
-    :href="fixture.sport.slug"
+    :href="'activities/' + fixture.sport.slug"
     class="w-full flex flex-col gap-2 lg:gap-0 lg:flex-row fixtureTile"
   >
     <div class="fixtureTime">
@@ -25,7 +25,7 @@
         </p>
       </div>
     </div>
-    <div class="flex flex-col gap-2">
+    <div class="flex flex-col gap-2 lg:pr-24 lg:pl-16">
       <div
         class="flex items-center justify-start sm:justify-end gap-6 sm:gap-8"
       >
@@ -35,6 +35,9 @@
             <p v-if="York && York.result" class="text-xl lg:text-2xl">
               {{ formatScore(York.result.score) }}
             </p>
+            <p v-else class="">
+              <i class="fa-regular fa-clock"></i>
+            </p>
           </div>
         </div>
         <div class="flex gap-4 items-center">
@@ -42,6 +45,9 @@
           <div class="scoreTile scoreTileLancaster">
             <p v-if="Lancaster && Lancaster.result" class="text-xl lg:text-2xl">
               {{ formatScore(Lancaster.result.score) }}
+            </p>
+            <p v-else class="">
+              <i class="fa-regular fa-clock"></i>
             </p>
           </div>
         </div>

--- a/components/LoadingFixtureTile.vue
+++ b/components/LoadingFixtureTile.vue
@@ -9,50 +9,31 @@
     </div>
     <div class="flex flex-col gap-2 flex-grow fixtureDetails">
       <div class="flex flex-wrap gap-2">
-        <div class="w-50 h-6 bg-gray-200 rounded"></div>
-        <div class="w-40 h-6 bg-gray-200 rounded"></div>
+        <div class="w-50 h-4 lg:h-6 bg-gray-200 rounded"></div>
+        <div class="w-40 h-4 lg:h-6 bg-gray-200 rounded"></div>
       </div>
       <div class="flex justify-between">
-        <div class="w-60 h-4 bg-gray-200 rounded"></div>
-        <div class="block lg:hidden w-20 h-4 bg-gray-200 rounded"></div>
+        <div class="w-60 h-2 lg:h-4 bg-gray-200 rounded"></div>
+        <div class="block lg:hidden w-20 h-2 lg:h-4 bg-gray-200 rounded"></div>
       </div>
     </div>
-    <!-- <div class="flex flex-col gap-2 lg:pr-24 lg:pl-16">
+    <div class="flex flex-col gap-2 lg:pr-24 lg:pl-16">
       <div
         class="flex items-center justify-start sm:justify-end gap-6 sm:gap-8"
       >
         <div class="flex gap-4 items-center">
-          <p class="font-semibold text-lg lg:text-2xl">YORK</p>
-          <div class="scoreTile scoreTileYork">
-            <p v-if="York && York.result" class="text-xl lg:text-2xl">
-              {{ formatScore(York.result.score) }}
-            </p>
-            <p v-else class="">
-              <i class="fa-regular fa-clock"></i>
-            </p>
-          </div>
+          <div class="h-4 lg:h-6 w-20 lg:w-30 bg-gray-200 rounded"></div>
+          <div class="w-9 h-9 bg-gray-200 rounded"></div>
         </div>
         <div class="flex gap-4 items-center">
-          <p class="font-semibold text-lg lg:text-2xl">LANCASTER</p>
-          <div class="scoreTile scoreTileLancaster">
-            <p v-if="Lancaster && Lancaster.result" class="text-xl lg:text-2xl">
-              {{ formatScore(Lancaster.result.score) }}
-            </p>
-            <p v-else class="">
-              <i class="fa-regular fa-clock"></i>
-            </p>
-          </div>
+          <div class="h-4 lg:h-6 w-20 lg:w-30 bg-gray-200 rounded"></div>
+          <div class="w-9 h-9 bg-gray-200 rounded"></div>
         </div>
       </div>
       <div class="hidden lg:flex items-center justify-end">
-        <p
-          v-if="fixture.scoringRules[0].pointsValue !== 0"
-          class="whitespace-nowrap"
-        >
-          {{ fixture.scoringRules[0].pointsValue }} POINTS
-        </p>
+        <div class="w-10 h-2 lg:h-4 bg-gray-200 rounded"></div>
       </div>
-    </div> -->
+    </div>
   </div>
 </template>
 

--- a/components/LoadingFixtureTile.vue
+++ b/components/LoadingFixtureTile.vue
@@ -1,0 +1,63 @@
+<template>
+  <div
+    class="w-full flex flex-col gap-2 lg:gap-0 lg:flex-row fixtureTile animate-pulse"
+  >
+    <div class="fixtureTime">
+      <div
+        class="w-15 h-5 flex lg:justify-center items-center bg-gray-200 rounded"
+      ></div>
+    </div>
+    <div class="flex flex-col gap-2 flex-grow fixtureDetails">
+      <div class="flex flex-wrap gap-2">
+        <div class="w-50 h-6 bg-gray-200 rounded"></div>
+        <div class="w-40 h-6 bg-gray-200 rounded"></div>
+      </div>
+      <div class="flex justify-between">
+        <div class="w-60 h-4 bg-gray-200 rounded"></div>
+        <div class="block lg:hidden w-20 h-4 bg-gray-200 rounded"></div>
+      </div>
+    </div>
+    <!-- <div class="flex flex-col gap-2 lg:pr-24 lg:pl-16">
+      <div
+        class="flex items-center justify-start sm:justify-end gap-6 sm:gap-8"
+      >
+        <div class="flex gap-4 items-center">
+          <p class="font-semibold text-lg lg:text-2xl">YORK</p>
+          <div class="scoreTile scoreTileYork">
+            <p v-if="York && York.result" class="text-xl lg:text-2xl">
+              {{ formatScore(York.result.score) }}
+            </p>
+            <p v-else class="">
+              <i class="fa-regular fa-clock"></i>
+            </p>
+          </div>
+        </div>
+        <div class="flex gap-4 items-center">
+          <p class="font-semibold text-lg lg:text-2xl">LANCASTER</p>
+          <div class="scoreTile scoreTileLancaster">
+            <p v-if="Lancaster && Lancaster.result" class="text-xl lg:text-2xl">
+              {{ formatScore(Lancaster.result.score) }}
+            </p>
+            <p v-else class="">
+              <i class="fa-regular fa-clock"></i>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="hidden lg:flex items-center justify-end">
+        <p
+          v-if="fixture.scoringRules[0].pointsValue !== 0"
+          class="whitespace-nowrap"
+        >
+          {{ fixture.scoringRules[0].pointsValue }} POINTS
+        </p>
+      </div>
+    </div> -->
+  </div>
+</template>
+
+<script>
+export default {
+  name: "LoadingFixtureTile",
+};
+</script>

--- a/pages/fixtures/index.vue
+++ b/pages/fixtures/index.vue
@@ -6,14 +6,19 @@
     />
     <div class="container mx-auto py-28">
       <div class="pb-12 lg:pb-28 flex flex-col gap-8">
-        <DayFilters />
+        <DayFilters @select-day="updateDay" />
         <FixtureSearch />
       </div>
-      <FixtureTile
-        v-for="fixture in fixtures"
-        :key="fixture.id"
-        :fixture="fixture"
-      />
+      <div v-if="!loading">
+        <FixtureTile
+          v-for="fixture in fixtures"
+          :key="fixture.id"
+          :fixture="fixture"
+        />
+      </div>
+      <div v-else>
+        <LoadingFixtureTile />
+      </div>
     </div>
   </div>
 </template>
@@ -23,6 +28,7 @@ import HeroBanner from "~/components/HeroBanner.vue";
 import FixtureTile from "~/components/FixtureTile.vue";
 import DayFilters from "~/components/DayFilters.vue";
 import FixtureSearch from "~/components/FixtureSearch.vue";
+import LoadingFixtureTile from "~/components/LoadingFixtureTile.vue";
 export default {
   name: "FixturesPage",
   components: {
@@ -30,10 +36,13 @@ export default {
     FixtureTile,
     DayFilters,
     FixtureSearch,
+    LoadingFixtureTile,
   },
   data() {
     return {
       fixtures: [],
+      selectedDay: null,
+      loading: true,
     };
   },
   mounted() {
@@ -41,13 +50,24 @@ export default {
   },
   methods: {
     async fetchFixtures() {
+      this.loading = true;
       const response = await fetch(
-        "https://sports-admin.yorksu.org/api/clst1o9lv0001q5teb61pqfyy/seasons/clt4n09g7000hrtqt660v90bp/fixtures",
+        "https://sports-admin.yorksu.org/api/clst1o9lv0001q5teb61pqfyy/seasons/cm7uo6y6a0005nn0153286r5l/fixtures?" +
+          "startsAt=" +
+          this.selectedDay.startsAt +
+          "&endsAt=" +
+          this.selectedDay.endsAt,
       );
       this.fixtures = await response.json();
       this.fixtures = this.fixtures.sort((a, b) => {
         return new Date(a.startsAt) - new Date(b.startsAt);
       });
+      this.loading = false;
+    },
+    updateDay(day) {
+      console.log(day);
+      this.selectedDay = day;
+      this.fetchFixtures();
     },
   },
 };

--- a/pages/fixtures/index.vue
+++ b/pages/fixtures/index.vue
@@ -6,8 +6,8 @@
     />
     <div class="container mx-auto py-28">
       <div class="pb-12 lg:pb-28 flex flex-col gap-8">
-        <DayFilters @select-day="updateDay" />
-        <FixtureSearch />
+        <DayFilters :search-term="searchTerm" @select-day="updateDay" />
+        <FixtureSearch @search="updateSearch" />
       </div>
       <div v-if="!loading">
         <FixtureTile
@@ -43,6 +43,7 @@ export default {
       fixtures: [],
       selectedDay: null,
       loading: true,
+      searchTerm: "",
     };
   },
   mounted() {
@@ -51,12 +52,21 @@ export default {
   methods: {
     async fetchFixtures() {
       this.loading = true;
-      const response = await fetch(
-        "https://sports-admin.yorksu.org/api/clst1o9lv0001q5teb61pqfyy/seasons/cm7uo6y6a0005nn0153286r5l/fixtures?" +
+      let parameters = "";
+      if (this.selectedDay && this.searchTerm === "") {
+        parameters +=
           "startsAt=" +
           this.selectedDay.startsAt +
           "&endsAt=" +
-          this.selectedDay.endsAt,
+          this.selectedDay.endsAt;
+      }
+      if (this.searchTerm !== "") {
+        parameters += "&query=" + this.searchTerm;
+      }
+      console.log(parameters);
+      const response = await fetch(
+        "https://sports-admin.yorksu.org/api/clst1o9lv0001q5teb61pqfyy/seasons/cm7uo6y6a0005nn0153286r5l/fixtures?" +
+          parameters,
       );
       this.fixtures = await response.json();
       this.fixtures = this.fixtures.sort((a, b) => {
@@ -67,6 +77,11 @@ export default {
     updateDay(day) {
       console.log(day);
       this.selectedDay = day;
+      this.fetchFixtures();
+    },
+    updateSearch(search) {
+      console.log(search);
+      this.searchTerm = search;
       this.fetchFixtures();
     },
   },

--- a/pages/fixtures/index.vue
+++ b/pages/fixtures/index.vue
@@ -59,11 +59,9 @@ export default {
           this.selectedDay.startsAt +
           "&endsAt=" +
           this.selectedDay.endsAt;
+      } else if (this.searchTerm !== "") {
+        parameters = "&query=" + this.searchTerm;
       }
-      if (this.searchTerm !== "") {
-        parameters += "&query=" + this.searchTerm;
-      }
-      console.log(parameters);
       const response = await fetch(
         "https://sports-admin.yorksu.org/api/clst1o9lv0001q5teb61pqfyy/seasons/cm7uo6y6a0005nn0153286r5l/fixtures?" +
           parameters,
@@ -75,13 +73,14 @@ export default {
       this.loading = false;
     },
     updateDay(day) {
-      console.log(day);
       this.selectedDay = day;
       this.fetchFixtures();
     },
     updateSearch(search) {
-      console.log(search);
       this.searchTerm = search;
+      if (this.searchTerm === "") {
+        this.selectedDay = this.$refs.dayFilters.selectedDay;
+      }
       this.fetchFixtures();
     },
   },


### PR DESCRIPTION
### Description

This pull request includes significant updates to the `DayFilters.vue`, `FixtureTile.vue`, and `LoadingFixtureTile.vue` components, as well as modifications to the `fixtures` page. The changes focus on enhancing the user interface and improving the functionality of selecting and displaying fixtures based on days.

Key changes include:

### Enhancements to Day Selection:
* [`components/DayFilters.vue`](diffhunk://#diff-91e1229dc5dfe79ac8157ae606c28aaaeff084f1af380cbea58285b8c619a7b0L4-R43): Replaced `RosesButton` components with custom `<button>` elements that dynamically update their styles based on the selected day and emit the `selectDay` event. Added methods to handle day selection and set the default day based on the current date. [[1]](diffhunk://#diff-91e1229dc5dfe79ac8157ae606c28aaaeff084f1af380cbea58285b8c619a7b0L4-R43) [[2]](diffhunk://#diff-91e1229dc5dfe79ac8157ae606c28aaaeff084f1af380cbea58285b8c619a7b0R58-R107)

### Improvements to Fixture Display:
* [`components/FixtureTile.vue`](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dL3-R3): Updated the `href` attribute for fixture links to include a specific path. Added placeholder elements to display a clock icon when fixture results are not available. [[1]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dL3-R3) [[2]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dL28-R28) [[3]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dR38-R40) [[4]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dR49-R51)
* [`components/LoadingFixtureTile.vue`](diffhunk://#diff-36c755ac1d7cad86f4b60270af43f6e11208fca380afb13c66e5eea2c0ee8f70R1-R63): Introduced a new component to show loading placeholders for fixtures, enhancing the user experience during data fetch operations.

### Updates to Fixtures Page:
* [`pages/fixtures/index.vue`](diffhunk://#diff-b5f58aadf9924f3343cc9001c00a1f68d29f03ba5a8c0f678293804170d03abdL9-R22): Integrated the `DayFilters` component to emit the `select-day` event and added the `LoadingFixtureTile` component to display loading states. Updated the fixtures fetching logic to filter results based on the selected day and manage loading states. [[1]](diffhunk://#diff-b5f58aadf9924f3343cc9001c00a1f68d29f03ba5a8c0f678293804170d03abdL9-R22) [[2]](diffhunk://#diff-b5f58aadf9924f3343cc9001c00a1f68d29f03ba5a8c0f678293804170d03abdR31-R70)

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
