### PR TITLE
use $fetch instead of fetch

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,7 +3,13 @@ import tailwindcss from "@tailwindcss/vite";
 
 export default defineNuxtConfig({
   compatibilityDate: "2024-11-01",
-  devtools: { enabled: true },
+  devtools: {
+    enabled: true,
+
+    timeline: {
+      enabled: true,
+    },
+  },
   vite: { plugins: [tailwindcss()] },
 
   nitro: { prerender: { autoSubfolderIndex: false } },

--- a/pages/fixtures/index.vue
+++ b/pages/fixtures/index.vue
@@ -47,7 +47,7 @@ export default {
     };
   },
   mounted() {
-    this.fetchFixtures();
+    useAsyncData(() => this.fetchFixtures());
   },
   methods: {
     async fetchFixtures() {
@@ -62,11 +62,10 @@ export default {
       } else if (this.searchTerm !== "") {
         parameters = "&query=" + this.searchTerm;
       }
-      const response = await fetch(
+      this.fixtures = await $fetch(
         "https://sports-admin.yorksu.org/api/clst1o9lv0001q5teb61pqfyy/seasons/cm7uo6y6a0005nn0153286r5l/fixtures?" +
           parameters,
       );
-      this.fixtures = await response.json();
       this.fixtures = this.fixtures.sort((a, b) => {
         return new Date(a.startsAt) - new Date(b.startsAt);
       });


### PR DESCRIPTION
### Description
This changes from `fetch` to `$fetch` [(nuxt docs)](https://nuxt.com/docs/getting-started/data-fetching) and then adds `useAsyncData` to prevent [double fetching of fixtures](https://nuxt.com/docs/getting-started/data-fetching#the-need-for-usefetch-and-useasyncdata) (once server and once client). @danrparker we should look at how best to optimise this for SSR to reduce load on the API.

This pull request includes changes to the `nuxt.config.ts` and `pages/fixtures/index.vue` files to enhance the development tools and improve the data fetching mechanism.

Enhancements to development tools:

* [`nuxt.config.ts`](diffhunk://#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07L6-R12): Enabled the timeline feature in the devtools configuration.

Improvements to data fetching:

* [`pages/fixtures/index.vue`](diffhunk://#diff-b5f58aadf9924f3343cc9001c00a1f68d29f03ba5a8c0f678293804170d03abdL50-R50): Replaced `this.fetchFixtures()` with `useAsyncData(() => this.fetchFixtures())` in the `mounted` lifecycle hook.
* [`pages/fixtures/index.vue`](diffhunk://#diff-b5f58aadf9924f3343cc9001c00a1f68d29f03ba5a8c0f678293804170d03abdL65-L69): Replaced `fetch` with `$fetch` for fetching fixtures data and removed the manual parsing of the response.

### Checklist

- [ ] I accept the contributor license agreement for this repository.
- [ ] All active GitHub checks for tests, formatting, and security are passing.
- [ ] The correct base branch is being used (if not `main`).
- [ ] A GitHub issue or linear task is linked to this pull request.
