### PR TITLE
Clear search on day change

### DIFF
--- a/components/DayFilters.vue
+++ b/components/DayFilters.vue
@@ -85,9 +85,9 @@ export default {
   },
   watch: {
     searchTerm() {
-      if (this.searchTerm === "") {
+      if (this.searchTerm === "" && this.selectedDay === null) {
         this.setDefaultDay();
-      } else {
+      } else if (this.searchTerm !== "") {
         this.selectedDay = null;
         this.$emit("selectDay", null);
       }

--- a/components/FixtureSearch.vue
+++ b/components/FixtureSearch.vue
@@ -3,6 +3,7 @@
     <form :action="search" class="w-full flex items-center h-10.5">
       <input
         id="searchInput"
+        ref="searchInput"
         type="text"
         class="w-full bg-light-gray px-6 py-2 rounded-s-lg border placeholder-slate-500 border-slate-300"
         placeholder="Search for a fixture or activity..."

--- a/pages/fixtures/index.vue
+++ b/pages/fixtures/index.vue
@@ -7,7 +7,7 @@
     <div class="container mx-auto py-28">
       <div class="pb-12 lg:pb-28 flex flex-col gap-8">
         <DayFilters :search-term="searchTerm" @select-day="updateDay" />
-        <FixtureSearch @search="updateSearch" />
+        <FixtureSearch ref="fixtureSearch" @search="updateSearch" />
       </div>
       <div v-if="!loading">
         <FixtureTile
@@ -73,6 +73,10 @@ export default {
     },
     updateDay(day) {
       this.selectedDay = day;
+      if (this.selectedDay !== null && this.searchTerm !== "") {
+        this.searchTerm = "";
+        this.$refs.fixtureSearch.$refs.searchInput.value = "";
+      }
       this.fetchFixtures();
     },
     updateSearch(search) {


### PR DESCRIPTION
### Description

This pull request includes changes to improve the search and filter functionalities in the fixtures component. The most important changes include adding conditions to handle empty search terms and selected days, and introducing references to manage search input values.

Improvements to search and filter logic:

* [`components/DayFilters.vue`](diffhunk://#diff-91e1229dc5dfe79ac8157ae606c28aaaeff084f1af380cbea58285b8c619a7b0L88-R90): Modified the `searchTerm` watcher to call `setDefaultDay` only when both `searchTerm` is empty and `selectedDay` is null. Additionally, it now sets `selectedDay` to null only when `searchTerm` is not empty.

Enhancements to search input management:

* [`components/FixtureSearch.vue`](diffhunk://#diff-6d7774c3c34fa57bf2fb1a208ea98052c0906155d75dcfeda102f0a5eb05d547R6): Added a `ref` attribute to the search input element to facilitate direct DOM manipulation.
* [`pages/fixtures/index.vue`](diffhunk://#diff-b5f58aadf9924f3343cc9001c00a1f68d29f03ba5a8c0f678293804170d03abdL10-R10): Added a `ref` attribute to the `FixtureSearch` component and updated the `updateDay` method to clear the search term and reset the search input value when a day is selected. [[1]](diffhunk://#diff-b5f58aadf9924f3343cc9001c00a1f68d29f03ba5a8c0f678293804170d03abdL10-R10) [[2]](diffhunk://#diff-b5f58aadf9924f3343cc9001c00a1f68d29f03ba5a8c0f678293804170d03abdR76-R79)

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
