### PR TITLE
Separate out "Before" and search by date

### DIFF
--- a/components/DayFilters.vue
+++ b/components/DayFilters.vue
@@ -66,18 +66,22 @@ export default {
     return {
       selectedDay: null,
       before: {
+        name: "Before",
         startsAt: "2025-03-05T00:00:00Z",
         endsAt: "2025-05-02T00:00:00Z",
       },
       friday: {
+        name: "Friday",
         startsAt: "2025-05-02T00:00:00Z",
         endsAt: "2025-05-03T00:00:00Z",
       },
       saturday: {
+        name: "Saturday",
         startsAt: "2025-05-03T00:00:00Z",
         endsAt: "2025-05-04T00:00:00Z",
       },
       sunday: {
+        name: "Sunday",
         startsAt: "2025-05-04T00:00:00Z",
         endsAt: "2025-05-05T00:00:00Z",
       },

--- a/pages/fixtures/index.vue
+++ b/pages/fixtures/index.vue
@@ -11,7 +11,7 @@
       </div>
       <div v-if="!loading">
         <div
-          v-for="(fixtures, date) in groupedFixtures"
+          v-for="(dayFixtures, date) in groupedFixtures"
           :key="date"
           class="not-last:mb-20"
         >
@@ -19,7 +19,7 @@
             {{ date }}
           </h2>
           <FixtureTile
-            v-for="fixture in fixtures"
+            v-for="fixture in dayFixtures"
             :key="fixture.id"
             :fixture="fixture"
           />

--- a/pages/fixtures/index.vue
+++ b/pages/fixtures/index.vue
@@ -10,11 +10,20 @@
         <FixtureSearch ref="fixtureSearch" @search="updateSearch" />
       </div>
       <div v-if="!loading">
-        <FixtureTile
-          v-for="fixture in fixtures"
-          :key="fixture.id"
-          :fixture="fixture"
-        />
+        <div
+          v-for="(fixtures, date) in groupedFixtures"
+          :key="date"
+          class="not-last:mb-20"
+        >
+          <h2 v-if="date" class="text-3xl font-bold lg:pl-13 mb-4 lg:mb-10">
+            {{ date }}
+          </h2>
+          <FixtureTile
+            v-for="fixture in fixtures"
+            :key="fixture.id"
+            :fixture="fixture"
+          />
+        </div>
       </div>
       <div v-else>
         <LoadingFixtureTile />
@@ -29,6 +38,7 @@ import FixtureTile from "~/components/FixtureTile.vue";
 import DayFilters from "~/components/DayFilters.vue";
 import FixtureSearch from "~/components/FixtureSearch.vue";
 import LoadingFixtureTile from "~/components/LoadingFixtureTile.vue";
+import { groupBy } from "lodash";
 export default {
   name: "FixturesPage",
   components: {
@@ -45,6 +55,21 @@ export default {
       loading: true,
       searchTerm: "",
     };
+  },
+  computed: {
+    groupedFixtures() {
+      const options = { weekday: "long", day: "numeric", month: "long" };
+      if (this.selectedDay?.name === "Before" || this.searchTerm !== "") {
+        return groupBy(this.fixtures, (fixture) => {
+          return new Date(fixture.startsAt).toLocaleDateString(
+            "en-GB",
+            options,
+          );
+        });
+      } else {
+        return { "": this.fixtures };
+      }
+    },
   },
   mounted() {
     useAsyncData(() => this.fetchFixtures());


### PR DESCRIPTION
### Description

This pull request includes changes to the `components/DayFilters.vue` and `pages/fixtures/index.vue` files to enhance the display and organization of fixture data. The most important changes include adding names to day filters, grouping fixtures by date, and importing necessary utilities.

Enhancements to day filters:

* [`components/DayFilters.vue`](diffhunk://#diff-91e1229dc5dfe79ac8157ae606c28aaaeff084f1af380cbea58285b8c619a7b0R69-R84): Added `name` properties to `before`, `friday`, `saturday`, and `sunday` filters.

Improvements to fixture display:

* [`pages/fixtures/index.vue`](diffhunk://#diff-b5f58aadf9924f3343cc9001c00a1f68d29f03ba5a8c0f678293804170d03abdR13-R27): Added a `v-for` loop to display grouped fixtures by date, including a date header for each group.

Code organization and utility import:

* [`pages/fixtures/index.vue`](diffhunk://#diff-b5f58aadf9924f3343cc9001c00a1f68d29f03ba5a8c0f678293804170d03abdR41): Imported the `groupBy` function from `lodash` to facilitate grouping fixtures by date.
* [`pages/fixtures/index.vue`](diffhunk://#diff-b5f58aadf9924f3343cc9001c00a1f68d29f03ba5a8c0f678293804170d03abdR59-R73): Added a computed property `groupedFixtures` to group fixtures by date, using the `groupBy` function and date formatting options.

#### UI Screenshots

![Screenshot 2025-03-11 at 10 55 00](https://github.com/user-attachments/assets/1c0fdaa7-9de9-4b9a-bd2a-481e6a143ed7)

![Screenshot 2025-03-11 at 10 54 25](https://github.com/user-attachments/assets/621feda0-ac04-444f-9107-37680e862788)

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
