### PR TITLE
Add date to weekend fixtures

### DIFF
--- a/pages/fixtures/index.vue
+++ b/pages/fixtures/index.vue
@@ -59,16 +59,9 @@ export default {
   computed: {
     groupedFixtures() {
       const options = { weekday: "long", day: "numeric", month: "long" };
-      if (this.selectedDay?.name === "Before" || this.searchTerm !== "") {
-        return groupBy(this.fixtures, (fixture) => {
-          return new Date(fixture.startsAt).toLocaleDateString(
-            "en-GB",
-            options,
-          );
-        });
-      } else {
-        return { "": this.fixtures };
-      }
+      return groupBy(this.fixtures, (fixture) => {
+        return new Date(fixture.startsAt).toLocaleDateString("en-GB", options);
+      });
     },
   },
   mounted() {


### PR DESCRIPTION
### Description

Add date to the top of fixtures page for Friday/Saturday/Sunday page, to add clarity for people viewing the timetable not during the weekend.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
