### PR TITLE
activity/[id] page with rules, fixtures, and historic fixtures

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -101,3 +101,7 @@ body .xcond {
 .fixtureDetails {
   @apply lg:pl-16;
 }
+
+.key-rules ol {
+  @apply list-decimal list-inside flex flex-col gap-2;
+}

--- a/components/FixtureTile.vue
+++ b/components/FixtureTile.vue
@@ -1,8 +1,5 @@
 <template>
-  <a
-    :href="'activities/' + fixture.sport.slug"
-    class="w-full flex flex-col gap-2 lg:gap-0 lg:flex-row fixtureTile"
-  >
+  <div class="w-full flex flex-col gap-2 lg:gap-0 lg:flex-row fixtureTile">
     <div class="fixtureTime">
       <p
         class="font-semibold text-xl lg:text-2xl w-15 flex lg:justify-center items-center"
@@ -61,7 +58,7 @@
         </p>
       </div>
     </div>
-  </a>
+  </div>
 </template>
 
 <script>

--- a/components/HistoricFixtureTile.vue
+++ b/components/HistoricFixtureTile.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="w-full flex flex-col gap-2 lg:gap-0 sm:flex-row fixtureTile">
+    <div class="flex gap-2">
+      <div class="lg:pl-24 lg:pr-16 sm:border-r border-slate-300">
+        <p
+          class="font-semibold text-xl lg:text-2xl w-15 flex lg:justify-center items-center"
+        >
+          {{ new Date(historicFixture.startsAt).getFullYear() }}
+        </p>
+      </div>
+      <div class="flex flex-col gap-2 lg:gap-0 flex-grow sm:pl-16">
+        <div class="flex flex-wrap gap-2 text-xl lg:text-2xl">
+          <h3 class="font-bold">
+            {{ historicFixture.teams[0].team.name }}
+          </h3>
+        </div>
+      </div>
+    </div>
+    <div class="flex flex-col gap-2 lg:pr-24 lg:pl-16">
+      <div
+        class="flex items-center justify-start sm:justify-end gap-6 sm:gap-8"
+      >
+        <div class="flex gap-4 items-center">
+          <p class="font-semibold text-lg lg:text-2xl">YORK</p>
+          <div class="scoreTile scoreTileYork">
+            <p class="text-xl lg:text-2xl">
+              {{ formatScore(historicFixture.teams[0].result.score) }}
+            </p>
+          </div>
+        </div>
+        <div class="flex gap-4 items-center">
+          <p class="font-semibold text-lg lg:text-2xl">LANCASTER</p>
+          <div class="scoreTile scoreTileLancaster">
+            <p class="text-xl lg:text-2xl">
+              {{ formatScore(historicFixture.teams[1].result.score) }}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "HistoricFixtureTile",
+  props: {
+    historicFixture: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  methods: {
+    formatScore(score) {
+      return score.toString().padStart(2, "0");
+    },
+  },
+};
+</script>

--- a/pages/fixtures/index.vue
+++ b/pages/fixtures/index.vue
@@ -18,11 +18,13 @@
           <h2 v-if="date" class="text-3xl font-bold lg:pl-13 mb-4 lg:mb-10">
             {{ date }}
           </h2>
-          <FixtureTile
+          <a
             v-for="fixture in dayFixtures"
             :key="fixture.id"
-            :fixture="fixture"
-          />
+            :href="'activities/' + fixture.sport.slug"
+          >
+            <FixtureTile :fixture="fixture" />
+          </a>
         </div>
       </div>
       <div v-else>


### PR DESCRIPTION
### Description

This pull request includes several changes to the fixture components and pages to improve the display and functionality of the fixtures and historic fixtures. The most important changes include updating the `FixtureTile` component, adding a new `HistoricFixtureTile` component, and modifying the `activities` page to display fixtures and historic fixtures more effectively.

### Component Updates:

* [`components/FixtureTile.vue`](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dL2-R2): Changed the wrapper element from an `<a>` tag to a `<div>` tag to avoid issues with nested interactive content. [[1]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dL2-R2) [[2]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dL64-R61)
* [`components/HistoricFixtureTile.vue`](diffhunk://#diff-a7a27de1ec3745b377c22ee2cb804f5f2eee0e25c021908fcae4e05fc699a1a2R1-R59): Added a new component to display historic fixtures, including methods to format scores and props to pass fixture data.

### Page Modifications:

* `pages/activities/[id].vue`: Updated the page to dynamically fetch and display current and historic fixtures based on the sport ID from the route parameters. Removed the `DayFilters` component and added the `FixtureTile` and `HistoricFixtureTile` components. ([pages/activities/[id].vueL4-R104](diffhunk://#diff-4a6cb4a42737ef40f1b9fa722aae786b7b8b596265ed6b764d7d8503553d2d26L4-R104))
* [`pages/fixtures/index.vue`](diffhunk://#diff-b5f58aadf9924f3343cc9001c00a1f68d29f03ba5a8c0f678293804170d03abdL21-R27): Modified the fixture links to wrap the `FixtureTile` component in an `<a>` tag for navigation purposes.

### Styling Updates:

* [`assets/css/main.css`](diffhunk://#diff-b15932692c619f9a334ecb156ac167557c3af214a8a3df8990c09232ac8a5baaR104-R107): Added new styling rules for the `.key-rules ol` class to apply list and flexbox utilities.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
