### PR TITLE
remove link to shop

### DIFF
--- a/components/footer.vue
+++ b/components/footer.vue
@@ -17,7 +17,7 @@
             <a href="/fixtures">Fixtures</a>
             <a href="/get-involved">Get Involved</a>
             <a href="/about">About</a>
-            <!-- <a href="food-drink">Food & Drink</a> -->
+            <!-- <a href="/food-drink">Food & Drink</a> -->
             <!-- <a href="https://yorksu.org/shop?category=9" target="_blank">
               Shop</a
             > -->

--- a/components/footer.vue
+++ b/components/footer.vue
@@ -13,15 +13,15 @@
         >
           <div class="flex flex-col gap-2 lg:gap-1">
             <h2 class="text-roses-red mb-2">Useful Links</h2>
-            <!-- <a>Roses Live</a>
-                        <a>Fixtures</a> -->
-            <a>Get Involved</a>
-            <a>About</a>
-            <a>Food & Drink</a>
-            <a href="https://yorksu.org/shop?category=9" target="_blank">
+            <!-- <a>Roses Live</a> -->
+            <a href="/fixtures">Fixtures</a>
+            <a href="/get-involved">Get Involved</a>
+            <a href="/about">About</a>
+            <!-- <a href="food-drink">Food & Drink</a> -->
+            <!-- <a href="https://yorksu.org/shop?category=9" target="_blank">
               Shop</a
-            >
-            <a>Map</a>
+            > -->
+            <!-- <a href="/map">Map</a> -->
           </div>
           <div class="flex flex-col gap-4">
             <div class="flex flex-col gap-2 lg:gap-1">


### PR DESCRIPTION
### Description

This pull request includes changes to the `components/footer.vue` file to update and clean up the list of links displayed in the footer. The most important changes include updating the URLs for the "Fixtures," "Get Involved," and "About" links, and commenting out several unused or outdated links.

Updates to footer links:

* Updated the "Fixtures" link to point to `/fixtures` instead of being commented out.
* Updated the "Get Involved" link to point to `/get-involved` instead of being a plain text link.
* Updated the "About" link to point to `/about` instead of being a plain text link.

Clean-up of unused links:

* Commented out the "Food & Drink" link and the link to the shop on `yorksu.org`.
* Commented out the "Map" link.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
