### PR TITLE
Add terms and conditions and meta tags for new pages

### DIFF
--- a/components/footer.vue
+++ b/components/footer.vue
@@ -17,6 +17,7 @@
                         <a>Fixtures</a> -->
             <a>Get Involved</a>
             <a>About</a>
+            <a href="/terms-and-conditions">Terms & Conditions</a>
             <a>Food & Drink</a>
             <a href="https://yorksu.org/shop?category=9" target="_blank">
               Shop</a

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -44,4 +44,7 @@ export default {
     HeroBanner,
   },
 };
+useHead({
+  title: "About | Roses Live",
+});
 </script>

--- a/pages/activities/[id].vue
+++ b/pages/activities/[id].vue
@@ -104,11 +104,12 @@ export default {
       this.historicFixtures = this.historicFixtures.sort((a, b) => {
         return new Date(b.startsAt) - new Date(a.startsAt);
       });
+      // SET PAGE TITLE
+      useHead({
+        title: `${this.sport?.name} | Roses Live`,
+      });
       this.loading = false;
     },
   },
 };
-useHead({
-  title: `Roses Live`,
-});
 </script>

--- a/pages/contributors/index.vue
+++ b/pages/contributors/index.vue
@@ -4,7 +4,7 @@
       title="CONTRIBUTORS"
       image="https://assets-cdn.sums.su/YU/website/img/Roses/Hero_Banner_Homepage.png"
     />
-    <div class="container mx-auto py-28">
+    <div class="container mx-auto py-28 gap-6">
       <p>
         The Roses Live website represents a collaborative effort between staff,
         students, and alumni from the

--- a/pages/get-involved/index.vue
+++ b/pages/get-involved/index.vue
@@ -66,4 +66,7 @@ export default {
     HeroBanner,
   },
 };
+useHead({
+  title: "Get Involved | Roses Live",
+});
 </script>

--- a/pages/terms-and-conditions/index.vue
+++ b/pages/terms-and-conditions/index.vue
@@ -1,0 +1,113 @@
+<template>
+  <div>
+    <HeroBanner
+      title="TERMS & CONDITIONS"
+      image="https://assets-cdn.sums.su/YU/website/img/Roses/Hero_Banner_Homepage.png"
+    />
+    <div class="container mx-auto py-28 flex flex-col">
+      <div class="pb-2">
+        <h2 class="text-2xl font-bold">Disclaimer</h2>
+        <p>
+          To the extent permitted by law, the Union provides this website and
+          its contents on an "as is" basis and makes no representation or
+          warranty of any kind regarding this website or any information,
+          content, products or services on it. The Union does not represent or
+          warrant that the information accessible via this website is accurate,
+          complete or current. In no circumstances, to the extent permitted by
+          law, shall the Union or or any of its officers or employees be liable
+          for any loss, additional costs or damage (howsoever arising) suffered
+          as a result of any use of this website or its contents.
+        </p>
+      </div>
+      <div class="pb-2">
+        <h2 class="text-2xl font-bold">Accessibility</h2>
+        <p>
+          The University of York Students' Union is committed to making this
+          website accessible as possible to all in accordance with W3C
+          recommendations. Any problems encountered with accessing material on
+          this site should be reported to
+          <a class="text-roses-red hover:underline" href="mailto:it@yorksu.org"
+            >it@yorksu.org</a
+          >.
+        </p>
+      </div>
+      <div class="pb-2">
+        <h2 class="text-2xl font-bold">Copyright</h2>
+        <p>
+          All the content of this website (including images), unless explicitly
+          stated otherwise, is copyright of the University of York Students'
+          Union and may not be reproduced without prior permission. By accessing
+          these web pages, you agree that any downloading of content is for
+          personal, non-commercial reference only. No part of this website may
+          be reproduced or transmitted in any form or by any means without the
+          prior consent of the Union. For any queries about re-use of content
+          from the website, please contact
+          <a
+            class="text-roses-red hover:underline"
+            href="mailto:enquiries@yorksu.org"
+            >enquiries@yorksu.org</a
+          >.
+        </p>
+      </div>
+      <div>
+        <h2 class="text-2xl font-bold">Cookies</h2>
+        <h3 className="text-xl  pt-4 font-bold">What Are Cookies?</h3>
+        <p>
+          A cookie is a small text file which helps your web browser navigate
+          through a particular website. The cookie can then be read back later
+          by the web browser as required. The use of cookies is a convenient way
+          of allowing a computer to remember specific information relating to a
+          website which has been visited.
+        </p>
+        <h3 className="text-xl  pt-4 font-bold">How We Use Cookies</h3>
+        <p>
+          We use cookies for a variety of reasons which are detailed below.
+          Unfortunately in most cases there are no industry standard options for
+          disabling cookies without completely disabling the functionality and
+          features they add to this site. It is recommended that you leave on
+          all cookies if you are not sure whether you need them or not in case
+          they are used to provide a service that you use.
+        </p>
+        <h3 className="text-xl  pt-4 font-bold">Disabling Cookies</h3>
+        <p>
+          You can prevent the setting of cookies by adjusting the settings on
+          your browser (see your browser documentation for how to do this). Be
+          aware that disabling cookies will affect the functionality of this and
+          many other websites that you visit.
+          <b>It is recommended that you do not disable cookies.</b>
+        </p>
+        <h3 className="text-xl  pt-4 font-bold">The Cookies We Set</h3>
+        <h4 className="pt-4 font-bold">Third Party Cookies</h4>
+        <p>This website will track your engagement using PostHog, including:</p>
+
+        <ul class="list-disc pl-8">
+          <li>Page and content views</li>
+          <li>Behaviours on the page such as scrolling or clicking</li>
+          <li>Date and time of your visit</li>
+          <li>Location you are visiting from</li>
+          <li>Browser you are using including version</li>
+          <li>Device model and operating system you are using</li>
+        </ul>
+        <p>
+          We do not collect or store any of your personal information, so this
+          information can’t be used to identify who you are.
+          <a
+            href="https://posthog.com/privacy"
+            target="_blank"
+            class="text-roses-red hover:underline"
+          >
+            Posthog's privacy policy can be viewed here</a
+          >.
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+import HeroBanner from "~/components/HeroBanner.vue";
+
+export default { name: "CookiePolicyPage", components: { HeroBanner } };
+useHead({
+  title: "Terms and Conditions | Roses Live",
+});
+</script>

--- a/pages/terms-and-conditions/index.vue
+++ b/pages/terms-and-conditions/index.vue
@@ -4,7 +4,7 @@
       title="TERMS & CONDITIONS"
       image="https://assets-cdn.sums.su/YU/website/img/Roses/Hero_Banner_Homepage.png"
     />
-    <div class="container mx-auto py-28 flex flex-col">
+    <div class="container mx-auto py-28 flex flex-col gap-6">
       <div class="pb-2">
         <h2 class="text-2xl font-bold">Disclaimer</h2>
         <p>

--- a/pages/terms-and-conditions/index.vue
+++ b/pages/terms-and-conditions/index.vue
@@ -51,7 +51,7 @@
       </div>
       <div>
         <h2 class="text-2xl font-bold">Cookies</h2>
-        <h3 className="text-xl  pt-4 font-bold">What Are Cookies?</h3>
+        <h3 className="text-xl pt-4 font-bold">What Are Cookies?</h3>
         <p>
           A cookie is a small text file which helps your web browser navigate
           through a particular website. The cookie can then be read back later
@@ -59,7 +59,7 @@
           of allowing a computer to remember specific information relating to a
           website which has been visited.
         </p>
-        <h3 className="text-xl  pt-4 font-bold">How We Use Cookies</h3>
+        <h3 className="text-xl pt-4 font-bold">How We Use Cookies</h3>
         <p>
           We use cookies for a variety of reasons which are detailed below.
           Unfortunately in most cases there are no industry standard options for
@@ -68,7 +68,7 @@
           all cookies if you are not sure whether you need them or not in case
           they are used to provide a service that you use.
         </p>
-        <h3 className="text-xl  pt-4 font-bold">Disabling Cookies</h3>
+        <h3 className="text-xl pt-4 font-bold">Disabling Cookies</h3>
         <p>
           You can prevent the setting of cookies by adjusting the settings on
           your browser (see your browser documentation for how to do this). Be
@@ -76,7 +76,7 @@
           many other websites that you visit.
           <b>It is recommended that you do not disable cookies.</b>
         </p>
-        <h3 className="text-xl  pt-4 font-bold">The Cookies We Set</h3>
+        <h3 className="text-xl pt-4 font-bold">The Cookies We Set</h3>
         <h4 className="pt-4 font-bold">Third Party Cookies</h4>
         <p>This website will track your engagement using PostHog, including:</p>
 


### PR DESCRIPTION
### Description
This pull request includes several changes to the `Roses Live` website, focusing on adding a new page for terms and conditions, as well as setting the page titles dynamically for various pages.

### New Page Addition:
* Added a new `Terms and Conditions` page with comprehensive content, including sections on Disclaimer, Accessibility, Copyright, and Cookies (`pages/terms-and-conditions/index.vue`).

### Dynamic Page Titles:
* Set the page title dynamically for the `About` page (`pages/about/index.vue`).
* Set the page title dynamically for the `Get Involved` page (`pages/get-involved/index.vue`).
* Set the page title dynamically for the `Activities` page, replacing the previous static title (`pages/activities/[id].vue`). ([pages/activities/[id].vueR107-L113](diffhunk://#diff-4a6cb4a42737ef40f1b9fa722aae786b7b8b596265ed6b764d7d8503553d2d26R107-L113))

### Footer Update:
* Added a link to the new `Terms & Conditions` page in the footer (`components/footer.vue`).

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
