### PR TITLE
Update media links in footer (#144)

### DIFF
--- a/components/footer.vue
+++ b/components/footer.vue
@@ -38,7 +38,9 @@
               >YSTV</a
             >
             <a href="https://ury.org.uk" target="_blank">URY</a>
-            <a href="https://www.youtube.com/@LancsLA1TV" target="_blank">LA1TV</a>
+            <a href="https://www.youtube.com/@LancsLA1TV" target="_blank"
+              >LA1TV</a
+            >
             <a href="https://bailriggfm.co.uk/" target="_blank">Bailrigg FM</a>
           </div>
         </div>

--- a/components/footer.vue
+++ b/components/footer.vue
@@ -38,7 +38,7 @@
               >YSTV</a
             >
             <a href="https://ury.org.uk" target="_blank">URY</a>
-            <a href="https://www.youtube.com/@LancsLA1TV">LA1TV</a>
+            <a href="https://www.youtube.com/@LancsLA1TV" target="_blank">LA1TV</a>
             <a href="https://bailriggfm.co.uk/" target="_blank">Bailrigg FM</a>
           </div>
         </div>

--- a/components/footer.vue
+++ b/components/footer.vue
@@ -11,31 +11,35 @@
         <div
           class="flex mb-10 lg:mb-0 text-white text-xs lg:text-sm gap-10 order-1 lg:order-2"
         >
-          <div class="flex flex-col gap-2 lg:gap-1">
-            <h2 class="text-roses-red mb-2">Useful Links</h2>
-            <!-- <a>Roses Live</a> -->
-            <a href="/fixtures">Fixtures</a>
-            <a href="/get-involved">Get Involved</a>
-            <a href="/about">About</a>
-            <!-- <a href="/food-drink">Food & Drink</a> -->
-            <!-- <a href="https://yorksu.org/shop?category=9" target="_blank">
-              Shop</a
-            > -->
-            <!-- <a href="/map">Map</a> -->
-            <a href="/terms-and-conditions">Terms & Conditions</a>
-          </div>
           <div class="flex flex-col gap-4">
             <div class="flex flex-col gap-2 lg:gap-1">
-              <h2 class="text-roses-red mb-2">Student Media</h2>
-              <a href="https://nouse.co.uk" target="_blank">Nouse</a>
-              <a href="https://ystv.co.uk" target="_blank">YSTV</a>
-              <a href="https://ury.org.uk" target="_blank">URY</a>
+              <h2 class="text-roses-red mb-2">Useful Links</h2>
+              <!-- <a>Roses Live</a> -->
+              <a href="/fixtures">Fixtures</a>
+              <a href="/get-involved">Get Involved</a>
+              <a href="/about">About</a>
+              <!-- <a href="/food-drink">Food & Drink</a> -->
+              <!-- <a href="https://yorksu.org/shop?category=9" target="_blank">
+                Shop</a
+              > -->
+              <!-- <a href="/map">Map</a> -->
+              <a href="/terms-and-conditions">Terms & Conditions</a>
             </div>
             <div class="flex flex-col gap-2 lg:gap-1">
               <h2 class="text-roses-red mb-2">Contact Details</h2>
               <!-- <a href="tel:01904323724">01904 32 3724</a> -->
               <a href="mailto:helpdesk@yorksu.org">helpdesk@yorksu.org</a>
             </div>
+          </div>
+          <div class="flex flex-col gap-2 lg:gap-1">
+            <h2 class="text-roses-red mb-2">Student Media</h2>
+            <a href="https://nouse.co.uk" target="_blank">Nouse</a>
+            <a href="https://youtube.com/@YorkStudentTV" target="_blank"
+              >YSTV</a
+            >
+            <a href="https://ury.org.uk" target="_blank">URY</a>
+            <a href="https://www.youtube.com/@LancsLA1TV">LA1TV</a>
+            <a href="https://bailriggfm.co.uk/" target="_blank">Bailrigg FM</a>
           </div>
         </div>
         <div class="flex w-56 items-center pt-6 order-3">


### PR DESCRIPTION
Resolves #144 

### Description

Changes YSTV to go to their YouTube channel, as well as adding Bailrigg FM and LA1TV.

![image](https://github.com/user-attachments/assets/eefe50c6-e9f2-4ce2-a080-874007ca0f0c)

I've also moved the Contact Details section to the first column, to make the two more even in height again

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
