### PR TITLE
swap images on tiles

### DIFF
--- a/components/CtaTiles.vue
+++ b/components/CtaTiles.vue
@@ -19,7 +19,7 @@
           </div>
           <img
             class="hover:scale-105 transition-all"
-            src="https://assets-cdn.sums.su/YU/website/img/Roses/Fixtures_Tile.png"
+            src="https://assets-cdn.sums.su/YU/website/img/Roses/Shop_Tile.png"
             alt="Fixtures"
           />
         </a>
@@ -35,7 +35,7 @@
           </div>
           <img
             class="hover:scale-105 transition-all"
-            src="https://assets-cdn.sums.su/YU/website/img/Roses/Get_Involved_Tile.png"
+            src="https://assets-cdn.sums.su/YU/website/img/Roses/Food_Drink_Tile.png"
             alt="Get Involved"
           />
         </a>
@@ -51,7 +51,7 @@
           </div>
           <img
             class="hover:scale-105 transition-all"
-            src="https://assets-cdn.sums.su/YU/website/img/Roses/Food_Drink_Tile.png"
+            src="https://assets-cdn.sums.su/YU/website/img/Roses/Get_Involved_Tile.png"
             alt="Food & Drink"
           />
         </a>
@@ -68,7 +68,7 @@
           </div>
           <img
             class="hover:scale-105 transition-all"
-            src="https://assets-cdn.sums.su/YU/website/img/Roses/Shop_Tile.png"
+            src="https://assets-cdn.sums.su/YU/website/img/Roses/Fixtures_Tile.png"
             alt="Shop"
           />
         </a> -->


### PR DESCRIPTION
### Description
This pull request includes updates to the image sources in the `CtaTiles.vue` component to correct the displayed images for various tiles.

Changes to `components/CtaTiles.vue`:

* Updated the image source for the "Fixtures" tile to `Shop_Tile.png`.
* Updated the image source for the "Get Involved" tile to `Food_Drink_Tile.png`.
* Updated the image source for the "Food & Drink" tile to `Get_Involved_Tile.png`.
* Updated the image source for the "Shop" tile to `Fixtures_Tile.png`.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
