### PR TITLE
Add parent location

### DIFF
--- a/components/FixtureTile.vue
+++ b/components/FixtureTile.vue
@@ -13,7 +13,7 @@
         <p v-if="York.team" class="">{{ York.team.name }}</p>
       </div>
       <div class="flex justify-between">
-        <p v-if="fixture.location">{{ fixture.location.name }}</p>
+        <p v-if="fixture.location">{{ locationName }}</p>
         <p
           v-if="fixture.scoringRules[0].pointsValue !== 0"
           class="block lg:hidden whitespace-nowrap"
@@ -57,7 +57,7 @@
               'Follow all the action live on roseslive.co.uk! Brought to you by York SU (yorksu.org). Fixture Details: https://roseslive.co.uk/activities/' +
               fixture.sport.slug
             "
-            :location="fixture.location.name"
+            :location="locationName"
           />
         </div>
       </div>
@@ -78,7 +78,7 @@
             'Follow all the action live on roseslive.co.uk! Brought to you by York SU (yorksu.org). Fixture Details: https://roseslive.co.uk/activities/' +
             fixture.sport.slug
           "
-          :location="fixture.location.name"
+          :location="locationName"
         />
       </div>
     </div>
@@ -118,6 +118,13 @@ export default {
         (team) => team.team.collectionId === this.yorkCollectionId,
       );
       return team ? team.team.name : null;
+    },
+    locationName() {
+      return `${this.fixture.location.name}${
+        this.fixture.location.parent
+          ? ", " + this.fixture.location.parent.name
+          : ""
+      }`;
     },
   },
   mounted() {


### PR DESCRIPTION
### Description
This pull request includes changes to the `components/FixtureTile.vue` file to improve the display and handling of fixture location names. The main change is the introduction of a new computed property to format location names, which is then used throughout the component.

Changes to fixture location handling:

* Added a new computed property `locationName` to format the fixture location name, including the parent location if available.
* Updated the template to use the new `locationName` computed property instead of directly accessing `fixture.location.name`. [[1]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dL16-R16) [[2]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dL60-R60) [[3]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dL81-R81)

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
