### PR TITLE
Separated parent and child locations

### DIFF
--- a/components/RosesMap.vue
+++ b/components/RosesMap.vue
@@ -10,6 +10,7 @@ export default {
       map: null,
       locations: [],
       formattedLocations: [],
+      formattedChildLocations: [],
       activeLocation: null,
       userCoordinates: null,
       route: null,
@@ -49,6 +50,14 @@ export default {
         },
         generateId: true,
       });
+      map.addSource("childLocations", {
+        type: "geojson",
+        data: {
+          type: "FeatureCollection",
+          features: this.formattedChildLocations,
+        },
+        generateId: true,
+      });
       map.addLayer({
         id: "locations",
         type: "circle",
@@ -82,52 +91,117 @@ export default {
           "text-anchor": "top",
         },
       });
+      map.addLayer({
+        id: "childLocations",
+        type: "circle",
+        source: "childLocations",
+        minzoom: 16,
+        paint: {
+          "circle-radius": [
+            "case",
+            ["boolean", ["feature-state", "active"], false],
+            10,
+            6,
+          ],
+          "circle-color": "#000000",
+          "circle-stroke-width": 3,
+          "circle-stroke-color": "#000000",
+          "circle-opacity": 0.8,
+          "circle-radius-transition": {
+            duration: 500,
+          },
+        },
+      });
+      map.addLayer({
+        id: "childLocations-labels",
+        type: "symbol",
+        source: "childLocations",
+        minzoom: 16,
+        layout: {
+          "text-field": "{name}",
+          "text-font": ["Poppins Medium"],
+          "text-size": 12,
+          "text-offset": [0, 1],
+          "text-anchor": "top",
+        },
+      });
       map.on("mouseenter", "locations", () => {
         map.getCanvas().style.cursor = "pointer";
       });
       map.on("mouseleave", "locations", () => {
         map.getCanvas().style.cursor = "";
       });
-      map.on("click", "locations", (e) => {
-        const coordinates = e.features[0].geometry.coordinates.slice();
-        const name = e.features[0].properties.name;
-        let facilities = e.features[0].properties.facilities;
-        try {
-          facilities = JSON.parse(facilities);
-        } catch {
-          facilities = [];
-        }
-        const facilitiesHTML =
-          facilities && facilities.length > 0
-            ? `<div class="flex flex-col gap-2"><h3>Facilities</h3><p>${facilities}</p></div>`
-            : "";
-        this.currentPopup = new mapboxgl.Popup()
-          .setLngLat(coordinates)
-          .setHTML(
-            `
-      <div class="flex flex-col p-1 gap-4">
-        <h2 class="text-2xl xcond">${name}</h2>
-        ${facilitiesHTML}
-        <div class="flex w-full justify-center"><button id="directionsButton" class="bg-roses-red text-white px-6 py-2 rounded-full text-center hover:cursor-pointer">Directions</button></div>
-      </div>
-    `,
-          )
-          .addTo(map);
-        this.$nextTick(() => {
-          const button = document.getElementById("directionsButton");
-          if (button) {
-            button.addEventListener("click", () => {
-              this.getRoute(coordinates);
-            });
-          }
-        });
-        this.updateActiveLocation(e);
+      map.on("mouseenter", "childLocations", () => {
+        map.getCanvas().style.cursor = "pointer";
+      });
+      map.on("mouseleave", "childLocations", () => {
+        map.getCanvas().style.cursor = "";
       });
       map.on("click", (e) => {
         const features = map.queryRenderedFeatures(e.point, {
-          layers: ["locations"],
+          layers: ["locations", "childLocations"],
         });
-        if (!features.length) {
+
+        if (features.length) {
+          const feature = features[0];
+          const layerId = feature.layer.id;
+          const coordinates = feature.geometry.coordinates.slice();
+          const name = feature.properties.name;
+          const id = feature.properties.id;
+          let facilities = feature.properties.facilities;
+
+          try {
+            facilities = JSON.parse(facilities);
+          } catch {
+            facilities = [];
+          }
+
+          const facilitiesHTML =
+            facilities && facilities.length > 0
+              ? `<div class="flex flex-col gap-2"><h3>Facilities</h3><p>${facilities}</p></div>`
+              : "";
+
+          const fixturesButton =
+            layerId === "childLocations"
+              ? `<a href="/fixtures?location=${id}" id="fixturesButton" class="bg-roses-red text-white px-6 py-2 rounded-full text-center hover:cursor-pointer">Fixtures</a>`
+              : "";
+
+          const parentName =
+            layerId === "childLocations"
+              ? `<p class="text-sm">${feature.properties.parentName}</p>`
+              : "";
+
+          this.currentPopup = new mapboxgl.Popup()
+            .setLngLat(coordinates)
+            .setHTML(
+              `
+        <div class="flex flex-col p-1 gap-4">
+          <div class="flex flex-col gap-1">
+            ${parentName}
+            <h2 class="text-2xl xcond">${name}</h2>
+          </div>
+          ${facilitiesHTML}
+          <div class="flex w-full justify-center gap-2">
+            <button id="directionsButton" class="bg-roses-red text-white px-6 py-2 rounded-full text-center hover:cursor-pointer">Directions</button>
+            ${fixturesButton}
+          </div>
+        </div>
+      `,
+            )
+            .addTo(map);
+
+          this.$nextTick(() => {
+            const directionsButton =
+              document.getElementById("directionsButton");
+            if (directionsButton) {
+              directionsButton.addEventListener("click", () => {
+                this.getRoute(coordinates);
+              });
+            }
+          });
+
+          this.updateActiveLocation({ features });
+        } else {
           if (this.activeLocation) {
             this.map.setFeatureState(
               { source: "locations", id: this.activeLocation },
@@ -137,6 +211,25 @@ export default {
           this.activeLocation = null;
         }
       });
+      map.on("zoom", () => {
+        const zoomLevel = map.getZoom();
+        if (this.currentPopup && this.activeLocation) {
+          const sourceFeatures = this.map.querySourceFeatures(
+            "childLocations",
+            {
+              sourceLayer: "childLocations",
+            },
+          );
+          const activeFeature = sourceFeatures.find(
+            (feature) => feature.id === this.activeLocation,
+          );
+          if (activeFeature && zoomLevel < 16) {
+            this.currentPopup.remove();
+            this.currentPopup = null;
+            this.activeLocation = null;
+          }
+        }
+      });
     });
   },
   methods: {
@@ -144,20 +237,44 @@ export default {
       this.locations = await $fetch(
         "https://sports-admin.yorksu.org/api/clst1o9lv0001q5teb61pqfyy/seasons/cm7uo6y6a0005nn0153286r5l/locations",
       );
-      this.formattedLocations = this.locations.map((location) => {
-        return {
+      for (let i = 0; i < this.locations.length; i++) {
+        this.formattedLocations.push({
           type: "Feature",
           properties: {
-            name: location.name,
-            id: location.id,
-            facilities: location.facilities,
+            name: this.locations[i].name,
+            id: this.locations[i].id,
+            facilities: this.locations[i].facilities,
           },
           geometry: {
             type: "Point",
-            coordinates: [location.longitude, location.latitude],
+            coordinates: [
+              this.locations[i].longitude,
+              this.locations[i].latitude,
+            ],
           },
-        };
-      });
+        });
+        if (this.locations[i].children.length > 0) {
+          for (let j = 0; j < this.locations[i].children.length; j++) {
+            this.formattedChildLocations.push({
+              type: "Feature",
+              properties: {
+                name: this.locations[i].children[j].name,
+                id: this.locations[i].children[j].id,
+                facilities: this.locations[i].children[j].facilities,
+                parentId: this.locations[i].id,
+                parentName: this.locations[i].name,
+              },
+              geometry: {
+                type: "Point",
+                coordinates: [
+                  this.locations[i].children[j].longitude,
+                  this.locations[i].children[j].latitude,
+                ],
+              },
+            });
+          }
+        }
+      }
     },
     updateActiveLocation(location) {
       if (this.activeLocation) {
@@ -176,20 +293,20 @@ export default {
           location.features[0].geometry.coordinates[0],
           location.features[0].geometry.coordinates[1],
         ],
-        zoom: 15,
+        zoom: location.features[0].layer.id === "locations" ? 17 : 19,
       });
     },
     async getRoute(destination) {
       if (this.userCoordinates) {
         this.route = await $fetch(
-          `https://api.mapbox.com/optimized-trips/v1/mapbox/walking/${this.userCoordinates[0]},${this.userCoordinates[1]};${destination}?geometries=geojson&access_token=${mapboxgl.accessToken}`,
+          `https://api.mapbox.com/directions/v5/mapbox/walking/${this.userCoordinates[0]},${this.userCoordinates[1]};${destination}?geometries=geojson&access_token=${mapboxgl.accessToken}`,
         );
       } else {
         this.route = await $fetch(
-          `https://api.mapbox.com/optimized-trips/v1/mapbox/walking/-1.055034237300904,53.94578819348761;${destination}?geometries=geojson&access_token=${mapboxgl.accessToken}`,
+          `https://api.mapbox.com/directions/v5/mapbox/walking/-1.055034237300904,53.94578819348761;${destination}?geometries=geojson&access_token=${mapboxgl.accessToken}`,
         );
       }
-      this.route = this.route.trips[0].geometry.coordinates;
+      this.route = this.route.routes[0].geometry.coordinates;
       const geojson = {
         type: "Feature",
         properties: {},
@@ -227,7 +344,7 @@ export default {
       this.route.forEach((coord) => bounds.extend(coord));
       this.map.fitBounds(bounds, {
         padding: { top: 50, bottom: 50, left: 50, right: 50 },
-        maxZoom: 15,
+        maxZoom: 16,
         duration: 1000,
       });
     },


### PR DESCRIPTION
### Description

This pull request introduces several changes to the `components/RosesMap.vue` file, primarily to enhance the handling and display of child locations on the map. The most important changes include adding new data structures and layers for child locations, updating event handling to accommodate these new layers, and refining the map's zoom behavior.

Enhancements to handling and display of child locations:

* Added a new data structure `formattedChildLocations` to store child location data.
* Added a new map source `childLocations` and corresponding layers (`childLocations` and `childLocations-labels`) to display child locations on the map. [[1]](diffhunk://#diff-09883069380466b34c4e89bd9df2616a3d0c9ab4823c595751bccc41e2882a9eR53-R60) [[2]](diffhunk://#diff-09883069380466b34c4e89bd9df2616a3d0c9ab4823c595751bccc41e2882a9eR94-R204)

Updates to event handling:

* Updated the click event handler to query and handle clicks on both `locations` and `childLocations` layers, displaying relevant information in popups.
* Introduced new event handlers for `mouseenter` and `mouseleave` on the `childLocations` layer to change the cursor style.

Refinements to zoom behavior:

* Added a zoom event handler to remove the popup and reset the active location when zooming out below a certain level.
* Adjusted the zoom levels for location centering and route fitting to better accommodate the new child location layers. [[1]](diffhunk://#diff-09883069380466b34c4e89bd9df2616a3d0c9ab4823c595751bccc41e2882a9eL179-R309) [[2]](diffhunk://#diff-09883069380466b34c4e89bd9df2616a3d0c9ab4823c595751bccc41e2882a9eL230-R347)

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
