### PR TITLE
View fixtures from locations and vice versa

### DIFF
--- a/components/DayFilters.vue
+++ b/components/DayFilters.vue
@@ -70,6 +70,7 @@ export default {
   data() {
     return {
       selectedDay: null,
+      locationId: null,
       before: {
         name: "Before",
         startsAt: "2025-03-05T00:00:00Z",
@@ -103,7 +104,13 @@ export default {
     },
   },
   mounted() {
-    this.setDefaultDay();
+    this.locationId = this.$route.query.location;
+    if (this.locationId) {
+      this.selectedDay = null;
+      this.$emit("selectDay", null);
+    } else {
+      this.setDefaultDay();
+    }
   },
   methods: {
     setDefaultDay() {

--- a/components/FixtureTile.vue
+++ b/components/FixtureTile.vue
@@ -24,31 +24,68 @@
     </div>
     <div class="flex flex-col gap-2 lg:pr-24 lg:pl-16">
       <div
-        class="flex items-center justify-start sm:justify-end gap-6 sm:gap-8"
+        class="flex flex-row lg:flex-col xl:flex-row items-center justify-start sm:justify-end gap-6 sm:gap-8"
       >
-        <div class="flex gap-4 items-center">
-          <p class="font-semibold text-lg lg:text-2xl">YORK</p>
-          <div class="scoreTile scoreTileYork">
-            <p v-if="York && York.result" class="text-xl lg:text-2xl">
-              {{ formatScore(York.result.score) }}
-            </p>
-            <p v-else class="">
-              <i class="fa-regular fa-clock"></i>
-            </p>
+        <div class="flex gap-6 sm:gap-8 w-full justify-end">
+          <div class="flex gap-4 items-center">
+            <p class="font-semibold text-lg lg:text-2xl">YORK</p>
+            <div class="scoreTile scoreTileYork">
+              <p v-if="York && York.result" class="text-xl lg:text-2xl">
+                {{ formatScore(York.result.score) }}
+              </p>
+              <p v-else class="">
+                <i class="fa-regular fa-clock"></i>
+              </p>
+            </div>
+          </div>
+          <div class="flex gap-4 items-center">
+            <p class="font-semibold text-lg lg:text-2xl">LANCASTER</p>
+            <div class="scoreTile scoreTileLancaster">
+              <p
+                v-if="Lancaster && Lancaster.result"
+                class="text-xl lg:text-2xl"
+              >
+                {{ formatScore(Lancaster.result.score) }}
+              </p>
+              <p v-else class="">
+                <i class="fa-regular fa-clock"></i>
+              </p>
+            </div>
           </div>
         </div>
-        <div class="flex gap-4 items-center">
-          <p class="font-semibold text-lg lg:text-2xl">LANCASTER</p>
-          <div class="scoreTile scoreTileLancaster">
-            <p v-if="Lancaster && Lancaster.result" class="text-xl lg:text-2xl">
-              {{ formatScore(Lancaster.result.score) }}
-            </p>
-            <p v-else class="">
-              <i class="fa-regular fa-clock"></i>
-            </p>
+        <div class="flex gap-2 lg:w-full justify-end">
+          <div v-if="fixture.startsAt" class="hidden md:flex items-center">
+            <add-to-calendar
+              :start-date="fixture.startsAt"
+              :end-date="fixture.endsAt"
+              :title="fixture.sport.name + ' - ' + teamName"
+              :description="
+                'Follow all the action live on roseslive.co.uk! Brought to you by York SU (yorksu.org). Fixture Details: https://roseslive.co.uk/activities/' +
+                fixture.sport.slug
+              "
+              :location="locationName"
+            />
+          </div>
+          <div class="hidden md:flex items-center">
+            <a
+              class="flex gap-2 bg-roses-red text-white px-6 md:px-3 py-2 text-center hover:bg-roses-red-dark transition duration-200 ease-in-out scoreTile"
+              alt="See on map"
+              :href="'/map?location=' + fixture.location.id"
+              ><i class="fa-solid fa-location-dot text-2xl"></i
+            ></a>
           </div>
         </div>
-        <div v-if="fixture.startsAt" class="hidden md:flex items-center">
+      </div>
+      <div class="hidden lg:flex items-center justify-end">
+        <p
+          v-if="fixture.scoringRules[0].pointsValue !== 0"
+          class="whitespace-nowrap"
+        >
+          {{ fixture.scoringRules[0].pointsValue }} POINTS
+        </p>
+      </div>
+      <div class="flex md:hidden md:w-full justify-end gap-4">
+        <div v-if="fixture.startsAt" class="">
           <add-to-calendar
             :start-date="fixture.startsAt"
             :end-date="fixture.endsAt"
@@ -60,26 +97,14 @@
             :location="locationName"
           />
         </div>
-      </div>
-      <div class="hidden lg:flex items-center justify-end">
-        <p
-          v-if="fixture.scoringRules[0].pointsValue !== 0"
-          class="whitespace-nowrap"
-        >
-          {{ fixture.scoringRules[0].pointsValue }} POINTS
-        </p>
-      </div>
-      <div v-if="fixture.startsAt" class="md:hidden flex justify-end">
-        <add-to-calendar
-          :start-date="fixture.startsAt"
-          :end-date="fixture.endsAt"
-          :title="fixture.sport.name + ' - ' + teamName"
-          :description="
-            'Follow all the action live on roseslive.co.uk! Brought to you by York SU (yorksu.org). Fixture Details: https://roseslive.co.uk/activities/' +
-            fixture.sport.slug
-          "
-          :location="locationName"
-        />
+        <div class="flex items-center">
+          <a
+            class="flex gap-2 bg-roses-red text-white px-6 md:px-3 py-2 text-center hover:bg-roses-red-dark transition duration-200 ease-in-out scoreTile"
+            alt="See on map"
+            :href="'/map?location=' + fixture.location.id"
+            ><i class="fa-solid fa-location-dot text-2xl"></i
+          ></a>
+        </div>
       </div>
     </div>
   </div>

--- a/components/RosesMap.vue
+++ b/components/RosesMap.vue
@@ -18,6 +18,7 @@ export default {
     };
   },
   mounted() {
+    const urlLocationId = this.$route.query.location;
     this.getLocations();
     mapboxgl.accessToken =
       "pk.eyJ1IjoieXVzdWRldjAiLCJhIjoiY204em5udWdmMGRweTJxcjI2NHFoaWNudiJ9.Cn9SDKmXPg9AY0xa5LfUmQ";
@@ -125,6 +126,19 @@ export default {
           "text-anchor": "top",
         },
       });
+      if (urlLocationId) {
+        const locationFeature =
+          this.formattedLocations.find(
+            (feature) => feature.properties.id === urlLocationId,
+          ) ||
+          this.formattedChildLocations.find(
+            (feature) => feature.properties.id === urlLocationId,
+          );
+
+        if (locationFeature) {
+          this.updateActiveLocation({ features: [locationFeature] });
+        }
+      }
       map.on("mouseenter", "locations", () => {
         map.getCanvas().style.cursor = "pointer";
       });
@@ -277,23 +291,29 @@ export default {
       }
     },
     updateActiveLocation(location) {
-      if (this.activeLocation) {
+      if (location.features[0].id) {
+        if (this.activeLocation) {
+          this.map.setFeatureState(
+            { source: "locations", id: this.activeLocation },
+            { active: false },
+          );
+        }
+        this.activeLocation = location.features[0].id;
         this.map.setFeatureState(
-          { source: "locations", id: this.activeLocation },
-          { active: false },
+          { source: "locations", id: location.features[0].id },
+          { active: true },
         );
       }
-      this.activeLocation = location.features[0].id;
-      this.map.setFeatureState(
-        { source: "locations", id: location.features[0].id },
-        { active: true },
-      );
       this.map.flyTo({
         center: [
           location.features[0].geometry.coordinates[0],
           location.features[0].geometry.coordinates[1],
         ],
-        zoom: location.features[0].layer.id === "locations" ? 17 : 19,
+        zoom: location.features[0].layer
+          ? location.features[0].layer.id === "locations"
+            ? 17
+            : 19
+          : 16,
       });
     },
     async getRoute(destination) {

--- a/components/RosesMap.vue
+++ b/components/RosesMap.vue
@@ -170,13 +170,29 @@ export default {
             facilities = [];
           }
 
-          const facilitiesHTML =
+          let facilityContent = "";
+          if (facilities && facilities.length > 0) {
+            for (let i = 0; i < facilities.length; i++) {
+              let facilityDescription = "";
+              if (facilities[i].description) {
+                facilityDescription = `<p class="text-sm">${facilities[i].description}</p>`;
+              }
+              facilityContent += `
+                <div class="flex flex-col gap-1">
+                  <h4 class="text-base">${facilities[i].name}</h4>
+                  ${facilityDescription}
+                </div>
+              `;
+            }
+          }
+
+          const facilitiesContainer =
             facilities && facilities.length > 0
-              ? `<div class="flex flex-col gap-2"><h3>Facilities</h3><p>${facilities}</p></div>`
+              ? `<div class="flex flex-col gap-2"><h3 class="text-lg"">Facilities</h3>${facilityContent}</div>`
               : "";
 
           const fixturesButton =
-            layerId === "childLocations"
+            layerId === "childLocations" || !feature.properties.parent
               ? `<a href="/fixtures?location=${id}" id="fixturesButton" class="bg-roses-red text-white px-6 py-2 rounded-full text-center hover:cursor-pointer">Fixtures</a>`
               : "";
 
@@ -194,7 +210,7 @@ export default {
             ${parentName}
             <h2 class="text-2xl xcond">${name}</h2>
           </div>
-          ${facilitiesHTML}
+          ${facilitiesContainer}
           <div class="flex w-full justify-center gap-2">
             <button id="directionsButton" class="bg-roses-red text-white px-6 py-2 rounded-full text-center hover:cursor-pointer">Directions</button>
             ${fixturesButton}
@@ -258,6 +274,7 @@ export default {
             name: this.locations[i].name,
             id: this.locations[i].id,
             facilities: this.locations[i].facilities,
+            parent: this.locations[i].children.length > 0,
           },
           geometry: {
             type: "Point",

--- a/components/addToCalendar.vue
+++ b/components/addToCalendar.vue
@@ -3,7 +3,7 @@
     <div class="flex flex-col items-end justify-end">
       <a
         href="javascript:void(0)"
-        class="flex gap-2 bg-roses-red text-white px-6 md:px-3 py-2 text-center hover:bg-roses-red-dark transition duration-200 ease-in-out"
+        class="flex gap-2 bg-roses-red text-white px-6 md:px-3 py-2 text-center hover:bg-roses-red-dark transition duration-200 ease-in-out scoreTile"
         aria-label="Add to calendar"
         @click="togglePopUp()"
       >

--- a/pages/fixtures/index.vue
+++ b/pages/fixtures/index.vue
@@ -90,6 +90,7 @@ export default {
   methods: {
     async fetchFixtures() {
       this.loading = true;
+      const locationId = this.$route.query.location;
       let parameters = "";
       if (this.selectedDay && this.searchTerm === "") {
         parameters +=
@@ -99,6 +100,8 @@ export default {
           this.selectedDay.endsAt;
       } else if (this.searchTerm !== "") {
         parameters = "&query=" + this.searchTerm;
+      } else if (this.selectedDay === null) {
+        parameters = "location=" + locationId;
       }
       this.fixtures = await $fetch(
         "https://sports-admin.yorksu.org/api/clst1o9lv0001q5teb61pqfyy/seasons/cm7uo6y6a0005nn0153286r5l/fixtures?" +


### PR DESCRIPTION
### Description

This pull request includes several changes to enhance the functionality and user experience of the application. The changes primarily focus on adding location-based filtering and improving the layout and styling of various components.

### Location-based filtering and updates:

* [`components/DayFilters.vue`](diffhunk://#diff-91e1229dc5dfe79ac8157ae606c28aaaeff084f1af380cbea58285b8c619a7b0R73): Added `locationId` data property and updated the `mounted` method to handle location-based filtering by setting `selectedDay` to null if a location is provided in the query parameters. [[1]](diffhunk://#diff-91e1229dc5dfe79ac8157ae606c28aaaeff084f1af380cbea58285b8c619a7b0R73) [[2]](diffhunk://#diff-91e1229dc5dfe79ac8157ae606c28aaaeff084f1af380cbea58285b8c619a7b0R107-R113)
* [`components/RosesMap.vue`](diffhunk://#diff-09883069380466b34c4e89bd9df2616a3d0c9ab4823c595751bccc41e2882a9eR21): Added logic to handle location-based updates by checking the query parameters for a location ID and updating the active location accordingly. [[1]](diffhunk://#diff-09883069380466b34c4e89bd9df2616a3d0c9ab4823c595751bccc41e2882a9eR21) [[2]](diffhunk://#diff-09883069380466b34c4e89bd9df2616a3d0c9ab4823c595751bccc41e2882a9eR129-R141) [[3]](diffhunk://#diff-09883069380466b34c4e89bd9df2616a3d0c9ab4823c595751bccc41e2882a9eL159-R195) [[4]](diffhunk://#diff-09883069380466b34c4e89bd9df2616a3d0c9ab4823c595751bccc41e2882a9eL183-R213) [[5]](diffhunk://#diff-09883069380466b34c4e89bd9df2616a3d0c9ab4823c595751bccc41e2882a9eR277) [[6]](diffhunk://#diff-09883069380466b34c4e89bd9df2616a3d0c9ab4823c595751bccc41e2882a9eR311) [[7]](diffhunk://#diff-09883069380466b34c4e89bd9df2616a3d0c9ab4823c595751bccc41e2882a9eR323-R333)
* [`pages/fixtures/index.vue`](diffhunk://#diff-b5f58aadf9924f3343cc9001c00a1f68d29f03ba5a8c0f678293804170d03abdR93): Added logic to include location ID in the API request parameters when fetching fixtures if `selectedDay` is null. [[1]](diffhunk://#diff-b5f58aadf9924f3343cc9001c00a1f68d29f03ba5a8c0f678293804170d03abdR93) [[2]](diffhunk://#diff-b5f58aadf9924f3343cc9001c00a1f68d29f03ba5a8c0f678293804170d03abdR103-R104)

### Layout and styling improvements:

* [`components/FixtureTile.vue`](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dL27-R29): Improved the layout by adjusting the flex properties and adding a "See on map" button to display the fixture location on the map. [[1]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dL27-R29) [[2]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dL43-R56) [[3]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dR69-R77) [[4]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dL72-R88) [[5]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dR100-R108)
* [`components/addToCalendar.vue`](diffhunk://#diff-80cbd610117870688c01a71c9db328b2eda30b23ed115ba8f3c589903194bc31L6-R6): Added the `scoreTile` class to the "Add to calendar" button for consistent styling.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
