### PR TITLE
Roses live score component

### DIFF
--- a/components/LiveScore.vue
+++ b/components/LiveScore.vue
@@ -1,0 +1,97 @@
+<template>
+  <div class="flex flex-col gap-18 md:gap-12 xcond font-bold">
+    <div class="flex flex-col justify-center items-center gap-2 text-5xl">
+      <h2 class="text-center">POINTS REQUIRED TO WIN</h2>
+      <p class="">{{ pointsToWin }}</p>
+    </div>
+    <div
+      class="relative flex justify-center text-4xl md:text-5xl border-t-2 border-black md:border-0"
+    >
+      <div
+        class="flex flex-col gap-4 w-2/4 items-center md:items-start justify-end md:justify-center"
+      >
+        <p class="order-3 md:order-1">{{ york.points }}</p>
+        <div class="flex items-end md:hidden order-2 h-[24rem]">
+          <div
+            :style="{
+              height: (york.points / pointsToWin) * 100 + '%',
+            }"
+            class="w-30 bg-black"
+          ></div>
+        </div>
+        <div
+          :style="{
+            width: (york.points / pointsToWin) * 100 + '%',
+          }"
+          class="h-10 bg-black hidden md:block order-2"
+        ></div>
+        <p class="order-2 md:order-3">YORK</p>
+      </div>
+      <div class="absolute h-full hidden flex-col items-center gap-2 md:flex">
+        <img
+          src="https://assets-cdn.sums.su/YU/website/img/Roses/Trophy_icon.webp"
+          alt=""
+          class="w-9"
+        />
+        <div class="w-[2px] bg-black h-20"></div>
+      </div>
+      <div class="absolute flex md:hidden p-2 -top-7 bg-white">
+        <img
+          src="https://assets-cdn.sums.su/YU/website/img/Roses/Trophy_icon.webp"
+          alt=""
+          class="w-9"
+        />
+      </div>
+      <div
+        class="flex flex-col gap-4 w-2/4 items-center md:items-end justify-end md:justify-start"
+      >
+        <p class="order-3 md:order-1">{{ Lancaster.points }}</p>
+        <div
+          :style="{
+            height: (Lancaster.points / pointsToWin) * 100 + '%',
+          }"
+          class="w-30 bg-roses-red block md:hidden order-2"
+        ></div>
+        <div
+          :style="{
+            width: (Lancaster.points / pointsToWin) * 100 + '%',
+          }"
+          class="h-10 bg-roses-red hidden md:block order-2"
+        ></div>
+        <p class="order-2 md:order-3">LANCASTER</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      totalPointsAvailable: 0,
+      pointsToWin: 0,
+      york: {
+        points: 0,
+      },
+      Lancaster: {
+        points: 0,
+      },
+    };
+  },
+  mounted() {
+    this.getPoints();
+  },
+  methods: {
+    async getPoints() {
+      const response = await $fetch(
+        "https://sports-admin.yorksu.org/api/clst1o9lv0001q5teb61pqfyy/seasons/cm7uo6y6a0005nn0153286r5l",
+      );
+      this.totalPointsAvailable = response.competitionInfo.totalPointsAvailable;
+      this.pointsToWin = this.totalPointsAvailable / 2 + 0.5;
+      this.york.points = response.competitionInfo.pointsByCollection.York || 0;
+      this.Lancaster.points =
+        response.competitionInfo.pointsByCollection.Lancaster || 0;
+    },
+  },
+};
+</script>

--- a/pages/live/index.vue
+++ b/pages/live/index.vue
@@ -1,0 +1,27 @@
+<template>
+  <div>
+    <HeroBanner
+      title="ROSES LIVE"
+      image="https://assets-cdn.sums.su/YU/website/img/Roses/Hero_Banner_Roses_Live.png"
+    />
+    <div class="body">
+      <div class="container mx-auto py-28">
+        <LiveScore />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import HeroBanner from "~/components/HeroBanner.vue";
+import LiveScore from "~/components/LiveScore.vue";
+export default {
+  components: {
+    HeroBanner,
+    LiveScore,
+  },
+};
+useHead({
+  title: "Roses Live",
+});
+</script>


### PR DESCRIPTION
### Description

This pull request introduces a new "Roses Live" page that displays live scores for the York vs. Lancaster competition. The most important changes include the creation of a `LiveScore` component to handle the score display and the addition of a new page that integrates this component with a hero banner.

### New "Roses Live" Page:

* **Addition of `pages/live/index.vue`:** A new page has been created to serve as the "Roses Live" page. It includes a hero banner with a title and image, and integrates the `LiveScore` component to display live competition scores.

### Live Score Display:

* **Creation of `LiveScore` Component (`components/LiveScore.vue`):** A new component has been added to display live scores for York and Lancaster. It includes:
  - Dynamic bar and text visualizations for the scores.
  - A method (`getPoints`) to fetch live score data from an external API.
  - Responsive design to adapt to different screen sizes.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
