### PR TITLE
Added radio streams to live streams

### DIFF
--- a/components/LiveReporting.vue
+++ b/components/LiveReporting.vue
@@ -47,7 +47,12 @@
           </button>
         </div>
         <div v-if="accordionOpen" class="flex flex-col gap-6">
-          <div v-if="activeStream.content" class="aspect-video w-full">
+          <div
+            v-if="
+              activeStream.coverage === 'TVCoverage' && activeStream.content
+            "
+            class="aspect-video w-full"
+          >
             <iframe
               width="100%"
               height="100%"
@@ -60,19 +65,18 @@
               allowfullscreen
             ></iframe>
           </div>
-          <!-- <div class="flex flex-col gap-2">
-            <p class="text-2xl font-bold">
-              {{ activeStream.fixture.sport }}
-            </p>
-            <p class="text-xl font-semibold">
-              Listen to the live radio stream here!
-            </p>
+          <div
+            v-if="activeStream.coverage === 'RadioCoverage'"
+            class="h-50 w-full"
+          >
             <iframe
-              controls
+              width="100%"
+              height="100%"
+              :src="'https://radio.roses.media/embed/stream/' + activeStream.id"
               title="Live Radio Stream"
-              src="https://radio.roses.media/embed/stream/test-stream-01"
+              frameborder="0"
             ></iframe>
-          </div> -->
+          </div>
         </div>
       </div>
       <div v-if="!catchup" class="flex flex-col bg-light-gray p-8 gap-10">
@@ -640,6 +644,7 @@ export default {
           id: stream.id,
           fixture: stream.fixture,
           content: videoId,
+          coverage: stream.coverage,
         };
       });
 
@@ -649,6 +654,7 @@ export default {
           sport: "Roses Trailer",
         },
         content: "S_F-QjAy2Rg",
+        coverage: "TVCoverage",
       };
       this.streams.unshift(rosesTrailer);
       this.activeStream = rosesTrailer;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -101,6 +101,7 @@ export default defineNuxtConfig({
           "'self'",
           "https://www.youtube.com",
           "https://www.youtube-nocookie.com",
+          "https://radio.roses.media/",
         ],
         "upgrade-insecure-requests": true,
         "report-to": "csp-endpoint",


### PR DESCRIPTION
### Description

This pull request introduces support for distinguishing between TV and radio coverage in the `LiveReporting` component. It adds a new `coverage` property to the `activeStream` object, updates the conditional rendering logic to handle different coverage types, and ensures the necessary CSP (Content Security Policy) adjustments for embedding radio streams.

### Updates to `LiveReporting` component:

* Added a `coverage` property to the `activeStream` object to differentiate between TV and radio coverage. (`components/LiveReporting.vue`, [[1]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7R647) [[2]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7R657)
* Updated the conditional rendering logic to display TV coverage (`TVCoverage`) or radio coverage (`RadioCoverage`) based on the `coverage` property. (`components/LiveReporting.vue`, [[1]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7L50-R55) [[2]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7L63-R79)

### CSP adjustments:

* Added `https://radio.roses.media/` to the Content Security Policy (CSP) to allow embedding the radio stream iframe. (`nuxt.config.ts`, [nuxt.config.tsR104](diffhunk://#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07R104))

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
