### PR TITLE
Added main streams, and fixtures button

### DIFF
--- a/pages/live/index.vue
+++ b/pages/live/index.vue
@@ -4,6 +4,8 @@
       title="ROSES LIVE"
       image="https://assets-cdn.sums.su/YU/website/img/Roses/Hero_Banner_Homepage.png"
       sub-image="https://assets-cdn.sums.su/YU/website/img/Roses/Hero_banner_NEW_cropped.png"
+      button-title="Fixtures"
+      button-href="/fixtures"
     />
     <div class="body">
       <div class="container mx-auto py-28">


### PR DESCRIPTION
### Description

This pull request introduces enhancements to the live reporting functionality and updates the user interface for the live page. The most significant changes include adding support for "main streams" in the live reporting component, refactoring video ID extraction logic into a reusable method, and adding a new button to the live page hero component.

### Enhancements to live reporting functionality:

* [`components/LiveReporting.vue`](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7R586): Introduced a new `mainStreams` property to handle a separate set of streams fetched from a different API endpoint. Combined `mainStreams` and `streams` to ensure `mainStreams` appear first in the final streams array. [[1]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7R586) [[2]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7L629-R654)
* [`components/LiveReporting.vue`](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7R810-R819): Extracted the video ID parsing logic into a new reusable `extractVideoId` method to simplify and centralize the handling of YouTube URLs.

### User interface updates:

* [`pages/live/index.vue`](diffhunk://#diff-810271e551c54cab20c8efa19f34b240c63349df80f7e231680b9e49e1dbe3f9R7-R8): Added a "Fixtures" button to the live page hero component, linking to the `/fixtures` page for improved navigation.

Also closes [ROS-150](https://linear.app/yorksu/issue/ROS-151/add-main-streams-to-the-live-page)

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
