### PR TITLE
Updated staging urls to production

### DIFF
--- a/components/LiveReporting.vue
+++ b/components/LiveReporting.vue
@@ -623,10 +623,10 @@ export default {
   methods: {
     async getStreams() {
       const response = await $fetch(
-        "https://media-dashboard-staging.yorksu.org/api/cm5pijvl80000ltigazjog2kg/seasons/cm7w42e0x0001nr01mlt1ptmi/coverage",
+        "https://media-dashboard.yorksu.org/api/cm5pijvl80000ltigazjog2kg/seasons/cm7w42e0x0001nr01mlt1ptmi/coverage",
       );
       const mainStreamsResponse = await $fetch(
-        "https://media-dashboard-staging.yorksu.org/api/cm5pijvl80000ltigazjog2kg/seasons/cm99vmptc0001qp01s21a8egb/coverage",
+        "https://media-dashboard.yorksu.org/api/cm5pijvl80000ltigazjog2kg/seasons/cm99vmptc0001qp01s21a8egb/coverage",
       );
       this.mainStreams = mainStreamsResponse.map((stream) => ({
         id: stream.id,
@@ -672,7 +672,7 @@ export default {
         parameters += `&page=${this.page}`;
       }
       const response = await $fetch(
-        "https://media-dashboard-staging.yorksu.org/api/cm5pijvl80000ltigazjog2kg/seasons/cm7w42e0x0001nr01mlt1ptmi/blogs" +
+        "https://media-dashboard.yorksu.org/api/cm5pijvl80000ltigazjog2kg/seasons/cm7w42e0x0001nr01mlt1ptmi/blogs" +
           parameters,
       );
       this.blogs = response.data;
@@ -688,7 +688,7 @@ export default {
         parameters += `&page=${this.photosPage}`;
       }
       const response = await $fetch(
-        "https://media-dashboard-staging.yorksu.org/api/cm5pijvl80000ltigazjog2kg/seasons/cm7w42e0x0001nr01mlt1ptmi/photos" +
+        "https://media-dashboard.yorksu.org/api/cm5pijvl80000ltigazjog2kg/seasons/cm7w42e0x0001nr01mlt1ptmi/photos" +
           parameters,
       );
       this.photos = response.data;
@@ -704,7 +704,7 @@ export default {
         parameters += `&page=${this.scoresPage}`;
       }
       const response = await $fetch(
-        "https://sports-admin-staging.yorksu.org/api/clsbxap510000gv60in0ijvp1/seasons/clt8ogzi9000km29p876hqgvh/fixtures/results" +
+        "https://sports-admin.yorksu.org/api/clsbxap510000gv60in0ijvp1/seasons/clt8ogzi9000km29p876hqgvh/fixtures/results" +
           parameters,
       );
       this.scores = response.data;
@@ -720,13 +720,13 @@ export default {
         parameters += `&page=${this.allCoveragePage}`;
       }
       const response = await $fetch(
-        "https://media-dashboard-staging.yorksu.org/api/cm5pijvl80000ltigazjog2kg/seasons/cm7w42e0x0001nr01mlt1ptmi/print-coverage" +
+        "https://media-dashboard.yorksu.org/api/cm5pijvl80000ltigazjog2kg/seasons/cm7w42e0x0001nr01mlt1ptmi/print-coverage" +
           parameters,
       );
       this.allCoverage = response.data;
       if (this.allCoveragePage === 1) {
         const scoresResponse = await $fetch(
-          "https://sports-admin-staging.yorksu.org/api/clsbxap510000gv60in0ijvp1/seasons/clt8ogzi9000km29p876hqgvh/fixtures/results?pageSize=5",
+          "https://sports-admin.yorksu.org/api/clsbxap510000gv60in0ijvp1/seasons/clt8ogzi9000km29p876hqgvh/fixtures/results?pageSize=5",
         );
         if (this.allCoverage.length > 0) {
           const lastPublishedAt = new Date(

--- a/components/carousel.vue
+++ b/components/carousel.vue
@@ -87,7 +87,7 @@ export default {
       const sportName = this.$route.params.id;
 
       const response = await $fetch(
-        `https://media-dashboard-staging.yorksu.org/api/cm5pijvl80000ltigazjog2kg/seasons/cm7w42e0x0001nr01mlt1ptmi/photos?sport=${sportName}`,
+        `https://media-dashboard.yorksu.org/api/cm5pijvl80000ltigazjog2kg/seasons/cm7w42e0x0001nr01mlt1ptmi/photos?sport=${sportName}`,
       );
       this.banners = response.data;
     },


### PR DESCRIPTION
### Description

This pull request updates API endpoint URLs in the `components/LiveReporting.vue` and `components/carousel.vue` files to replace staging URLs with production URLs. This ensures the application fetches data from the correct production servers.

### API Endpoint Updates:

* Updated all API calls in `components/LiveReporting.vue` to use production URLs instead of staging URLs for various data types, including streams, blogs, photos, scores, and print coverage. [[1]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7L626-R629) [[2]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7L675-R675) [[3]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7L691-R691) [[4]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7L707-R707) [[5]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7L723-R729)
* Updated the API call in `components/carousel.vue` to use the production URL for fetching photos based on the sport name.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
