### PR TITLE
Changed home page to live page

### DIFF
--- a/components/LiveReporting.vue
+++ b/components/LiveReporting.vue
@@ -704,7 +704,7 @@ export default {
         parameters += `&page=${this.scoresPage}`;
       }
       const response = await $fetch(
-        "https://sports-admin-staging.yorksu.org/api/clsbxap510000gv60in0ijvp1/seasons/clt8ogzi9000km29p876hqgvh/fixtures/results" +
+        "https://sports-admin.yorksu.org/api/clst1o9lv0001q5teb61pqfyy/seasons/cm7uo6y6a0005nn0153286r5l/fixtures/results" +
           parameters,
       );
       this.scores = response.data;
@@ -726,7 +726,7 @@ export default {
       this.allCoverage = response.data;
       if (this.allCoveragePage === 1) {
         const scoresResponse = await $fetch(
-          "https://sports-admin-staging.yorksu.org/api/clsbxap510000gv60in0ijvp1/seasons/clt8ogzi9000km29p876hqgvh/fixtures/results?pageSize=5",
+          "https://sports-admin.yorksu.org/api/clst1o9lv0001q5teb61pqfyy/seasons/cm7uo6y6a0005nn0153286r5l/fixtures/results?pageSize=5",
         );
         if (this.allCoverage.length > 0) {
           const lastPublishedAt = new Date(

--- a/components/navbar.vue
+++ b/components/navbar.vue
@@ -76,7 +76,7 @@ export default {
     return {
       isMenuOpen: false,
       links: [
-        { name: "Roses Live", href: "/", hidden: true },
+        { name: "Roses Live", href: "/live", hidden: true },
         { name: "Fixtures", href: "/fixtures", hidden: false },
         { name: "Get Involved", href: "/get-involved", hidden: false },
         { name: "About", href: "/about", hidden: false },

--- a/pages/home/index.vue
+++ b/pages/home/index.vue
@@ -1,0 +1,135 @@
+<template>
+  <div>
+    <HeroBanner
+      title="THE BATTLE IS COMING HOME"
+      sub-title="Roses 2025"
+      button-title="Fixtures"
+      button-href="/fixtures"
+      image="https://assets-cdn.sums.su/YU/website/img/Roses/Hero_Banner_Homepage.png"
+      sub-image="https://assets-cdn.sums.su/YU/website/img/Roses/Hero_banner_NEW_cropped.png"
+    />
+    <div class="body">
+      <div class="pt-14 md:pt-28">
+        <TextImageSection
+          image="https://assets-cdn.sums.su/YU/website/img/Roses/About_Image_Homepage.png"
+          alt=""
+          title="About"
+          sub-title="ONE TEAM ONE YORK"
+        >
+          <template #text>
+            <p>
+              Roses is an annual sporting varsity between the University of York
+              and Lancaster University. Named for the War of the Roses, the
+              competition this year celebrates its 60th anniversary! We’ll be
+              hosting hundreds of sports fixtures and bonus events between
+              Friday 2 and Sunday 4 May.
+            </p>
+            <p>
+              If you aren’t a massive sports fan, you can still get involved in
+              the Roses buzz! Across the weekend, there will be a range of
+              events to attend across campus and in our venues. Keep an eye on
+              this website and
+              <a
+                class="text-roses-red hover:underline"
+                href="https://go.yorksu.org/vbmh9v6"
+                target="_blank"
+                >York SU socials</a
+              >
+              to be the first to hear more details.
+            </p>
+            <p>
+              Most events are free to attend, though a small number require
+              tickets. Visit the
+              <a
+                class="text-roses-red hover:underline"
+                href="https://go.yorksu.org/FaHGy1a"
+                target="_blank"
+                >York Students’ Union website</a
+              >
+              to purchase tickets.
+            </p>
+          </template>
+        </TextImageSection>
+      </div>
+      <div
+        class="flex flex-col items-center justify-center gap-14 py-14 md:py-28"
+      >
+        <div class="container mx-auto">
+          <h2 class="font-bold xcond text-5xl text-center">
+            COUNTDOWN TO ROSES 2025
+          </h2>
+        </div>
+        <RosesCountdown date="2025-05-02T20:00:00" />
+      </div>
+      <CtaTiles />
+      <div class="py-14 md:py-28">
+        <TextImageSection
+          image="https://assets-cdn.sums.su/YU/website/img/Roses/York_Mind_Image.jpg"
+          alt=""
+          title="Our Charity Partner"
+          sub-title="ROSES IN MIND"
+          button-title="Donate Now"
+          button-href="https://go.yorksu.org/UxA3oQP"
+          button-target="_blank"
+        >
+          <template #text>
+            <p>
+              Each year, we partner with a different charity. Across Roses
+              weekend, we raise awareness and money for the charity,
+              highlighting important causes. This year, we are partnering with
+              <a
+                class="text-roses-red hover:underline"
+                href="https://go.yorksu.org/TjTnAgh"
+                target="_blank"
+                >York Mind</a
+              >.
+            </p>
+            <p>
+              York Mind are an independent local mental health charity which
+              empowers individuals experiencing mental ill health to start on
+              the pathway to recovery, supported by one simple belief: the
+              condition should never define the person.
+            </p>
+            <p>
+              To mark the announcement, our Sports Officer, TJ, shared her story
+              of how sport helped her to overcome her own mental health
+              challenges.
+              <a
+                class="text-roses-red hover:underline"
+                href="https://go.yorksu.org/jeuA8pb"
+                target="_blank"
+                >Read TJ’s story: Sport and my mental health</a
+              >.
+            </p>
+          </template>
+        </TextImageSection>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import HeroBanner from "~/components/HeroBanner.vue";
+import RosesCountdown from "~/components/Countdown.vue";
+import CtaTiles from "~/components/CtaTiles.vue";
+import TextImageSection from "~/components/TextImageSection.vue";
+export default {
+  name: "IndexPage",
+  components: {
+    HeroBanner,
+    CtaTiles,
+    RosesCountdown,
+    TextImageSection,
+  },
+};
+useHead({
+  title: "Roses Live",
+  meta: [
+    {
+      name: "description",
+      content:
+        "Roses is an annual sporting varsity between the University of York and Lancaster University. Roses 2025 marks the 60th anniversary of the competition! #RosesAreWhite",
+    },
+  ],
+});
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -76,5 +76,12 @@ export default {
 };
 useHead({
   title: "Roses Live",
+  meta: [
+    {
+      name: "description",
+      content:
+        "Roses is an annual sporting varsity between the University of York and Lancaster University. Roses 2025 marks the 60th anniversary of the competition! #RosesAreWhite",
+    },
+  ],
 });
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,65 +1,18 @@
 <template>
   <div>
     <HeroBanner
-      title="THE BATTLE IS COMING HOME"
-      sub-title="Roses 2025"
-      button-title="Fixtures"
-      button-href="/fixtures"
+      title="ROSES LIVE"
       image="https://assets-cdn.sums.su/YU/website/img/Roses/Hero_Banner_Homepage.png"
       sub-image="https://assets-cdn.sums.su/YU/website/img/Roses/Hero_banner_NEW_cropped.png"
+      button-title="Fixtures"
+      button-href="/fixtures"
     />
     <div class="body">
-      <div class="pt-14 md:pt-28">
-        <TextImageSection
-          image="https://assets-cdn.sums.su/YU/website/img/Roses/About_Image_Homepage.png"
-          alt=""
-          title="About"
-          sub-title="ONE TEAM ONE YORK"
-        >
-          <template #text>
-            <p>
-              Roses is an annual sporting varsity between the University of York
-              and Lancaster University. Named for the War of the Roses, the
-              competition this year celebrates its 60th anniversary! We’ll be
-              hosting hundreds of sports fixtures and bonus events between
-              Friday 2 and Sunday 4 May.
-            </p>
-            <p>
-              If you aren’t a massive sports fan, you can still get involved in
-              the Roses buzz! Across the weekend, there will be a range of
-              events to attend across campus and in our venues. Keep an eye on
-              this website and
-              <a
-                class="text-roses-red hover:underline"
-                href="https://go.yorksu.org/vbmh9v6"
-                target="_blank"
-                >York SU socials</a
-              >
-              to be the first to hear more details.
-            </p>
-            <p>
-              Most events are free to attend, though a small number require
-              tickets. Visit the
-              <a
-                class="text-roses-red hover:underline"
-                href="https://go.yorksu.org/FaHGy1a"
-                target="_blank"
-                >York Students’ Union website</a
-              >
-              to purchase tickets.
-            </p>
-          </template>
-        </TextImageSection>
-      </div>
-      <div
-        class="flex flex-col items-center justify-center gap-14 py-14 md:py-28"
-      >
-        <div class="container mx-auto">
-          <h2 class="font-bold xcond text-5xl text-center">
-            COUNTDOWN TO ROSES 2025
-          </h2>
+      <div class="container mx-auto py-14 md:py-28">
+        <div class="pb-14 md:pb-28">
+          <LiveScore />
         </div>
-        <RosesCountdown date="2025-05-02T20:00:00" />
+        <LiveReporting />
       </div>
       <CtaTiles />
       <div class="py-14 md:py-28">
@@ -110,26 +63,18 @@
 
 <script>
 import HeroBanner from "~/components/HeroBanner.vue";
-import RosesCountdown from "~/components/Countdown.vue";
+import LiveScore from "~/components/LiveScore.vue";
+import LiveReporting from "~/components/LiveReporting.vue";
 import CtaTiles from "~/components/CtaTiles.vue";
-import TextImageSection from "~/components/TextImageSection.vue";
 export default {
-  name: "IndexPage",
   components: {
     HeroBanner,
+    LiveScore,
+    LiveReporting,
     CtaTiles,
-    RosesCountdown,
-    TextImageSection,
   },
 };
 useHead({
   title: "Roses Live",
-  meta: [
-    {
-      name: "description",
-      content:
-        "Roses is an annual sporting varsity between the University of York and Lancaster University. Roses 2025 marks the 60th anniversary of the competition! #RosesAreWhite",
-    },
-  ],
 });
 </script>


### PR DESCRIPTION
### Description

This pull request introduces multiple updates to the `Roses Live` project, focusing on API updates, navigation improvements, and significant changes to the homepage layout and content. The changes include updating API endpoints, modifying navigation links, and restructuring the homepage to enhance user experience and highlight live reporting and scores.

### API Updates:
* Updated API endpoints in `components/LiveReporting.vue` to use production URLs instead of staging URLs for fetching fixture results. [[1]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7L707-R707) [[2]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7L729-R729)

### Navigation Improvements:
* Changed the "Roses Live" navigation link in `components/navbar.vue` to point to `/live` instead of `/`.

### Homepage Redesign:
* Added a new `pages/home/index.vue` file with a redesigned homepage featuring a hero banner, countdown to the event, charity partner section, and other content. This page highlights the upcoming Roses 2025 event and its associated activities.
* Updated `pages/index.vue` to focus on live reporting and scores instead of the general event overview. Removed sections related to the event description and countdown, and replaced them with `LiveScore` and `LiveReporting` components. [[1]](diffhunk://#diff-02281a80fab758cb4e8e8359b222a8a5afeaa9d5a7ba858f15d852f1f8969ecfL4-R15) [[2]](diffhunk://#diff-02281a80fab758cb4e8e8359b222a8a5afeaa9d5a7ba858f15d852f1f8969ecfL113-L133)

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
