### PR TITLE
Clearer fixture winner & fixture tile UI tweaks

### DIFF
--- a/components/FixtureTile.vue
+++ b/components/FixtureTile.vue
@@ -13,7 +13,7 @@
         <h3 class="font-bold">{{ fixture.sport.name }}</h3>
         <p v-if="York.team" class="">{{ York.team.name }}</p>
       </div>
-      <div class="flex justify-between">
+      <div class="flex justify-between items-center">
         <div>
           <p v-if="fixture.location">{{ locationName }}</p>
           <p v-if="fixture.highlighted" class="text-sm text-roses-red">
@@ -26,9 +26,31 @@
             {{ fixture.status }}
           </p>
         </div>
+        <div class="hidden sm:flex lg:hidden flex-grow justify-end">
+          <div
+            v-if="York && York.outcome === 'Win'"
+            class="flex pr-10 md:pr-58"
+          >
+            <p class="font-bold text-xl">YORK WIN</p>
+          </div>
+          <div
+            v-else-if="Lancaster && Lancaster.outcome === 'Win'"
+            class="flex pr-10"
+          >
+            <p class="font-bold text-xl xl:pl-19 text-roses-red">
+              LANCASTER WIN
+            </p>
+          </div>
+          <div
+            v-else-if="York && York.outcome === 'Draw'"
+            class="flex pr-10 md:pr-58"
+          >
+            <p class="font-bold text-xl">DRAW</p>
+          </div>
+        </div>
         <p
           v-if="fixture.scoringRules[0].pointsValue !== 0"
-          class="block lg:hidden whitespace-nowrap"
+          class="block lg:hidden whitespace-nowrap pl-1"
         >
           {{ fixture.scoringRules[0].pointsValue }} POINTS
         </p>
@@ -36,37 +58,78 @@
     </div>
     <div class="flex flex-col gap-2 lg:pr-24 lg:pl-16">
       <div
-        class="flex flex-row lg:flex-col xl:flex-row items-center justify-start sm:justify-end gap-6 sm:gap-8"
+        class="flex flex-row lg:flex-col xl:flex-row items-start justify-start sm:justify-end gap-6 sm:gap-8"
       >
-        <div class="flex gap-6 sm:gap-8 w-full justify-end">
-          <div class="flex gap-4 items-center">
-            <p class="font-semibold text-lg lg:text-2xl">YORK</p>
-            <div class="scoreTile scoreTileYork">
-              <p v-if="York && York.result" class="text-xl lg:text-2xl">
-                {{ formatScore(York.result.score) }}
-              </p>
-              <p v-else class="">
-                <i class="fa-regular fa-clock"></i>
-              </p>
+        <div class="flex flex-col xs:flex-row sm:flex-col gap-2 xs:w-full">
+          <div class="flex gap-6 sm:gap-8 w-full sm:justify-end">
+            <div class="flex gap-4 items-center">
+              <p class="font-semibold text-lg lg:text-2xl">YORK</p>
+              <div class="scoreTile scoreTileYork">
+                <p v-if="York && York.result" class="text-xl lg:text-2xl">
+                  {{ formatScore(York.result.score) }}
+                </p>
+                <p v-else class="">
+                  <i class="fa-regular fa-clock"></i>
+                </p>
+              </div>
+            </div>
+            <div class="flex gap-4 items-center">
+              <p class="font-semibold text-lg lg:text-2xl">LANCASTER</p>
+              <div class="scoreTile scoreTileLancaster">
+                <p
+                  v-if="Lancaster && Lancaster.result"
+                  class="text-xl lg:text-2xl"
+                >
+                  {{ formatScore(Lancaster.result.score) }}
+                </p>
+                <p v-else class="">
+                  <i class="fa-regular fa-clock"></i>
+                </p>
+              </div>
             </div>
           </div>
-          <div class="flex gap-4 items-center">
-            <p class="font-semibold text-lg lg:text-2xl">LANCASTER</p>
-            <div class="scoreTile scoreTileLancaster">
-              <p
-                v-if="Lancaster && Lancaster.result"
-                class="text-xl lg:text-2xl"
+          <div class="flex md:hidden flex-grow justify-end gap-2 items-center">
+            <div class="flex xs:hidden flex-grow">
+              <div v-if="York && York.outcome === 'Win'" class="flex flex-grow">
+                <p class="font-bold text-xl">YORK WIN</p>
+              </div>
+              <div
+                v-else-if="Lancaster && Lancaster.outcome === 'Win'"
+                class="flex flex-grow xl:justify-center"
               >
-                {{ formatScore(Lancaster.result.score) }}
-              </p>
-              <p v-else class="">
-                <i class="fa-regular fa-clock"></i>
-              </p>
+                <p class="font-bold text-xl text-roses-red">LANCASTER WIN</p>
+              </div>
+              <div
+                v-else-if="York && York.outcome === 'Draw'"
+                class="flex flex-grow"
+              >
+                <p class="font-bold text-xl">DRAW</p>
+              </div>
+            </div>
+            <div v-if="fixture.startsAt" class="">
+              <add-to-calendar
+                :start-date="fixture.startsAt"
+                :end-date="fixture.endsAt"
+                :title="fixture.sport.name + ' - ' + teamName"
+                :description="
+                  'Follow all the action live on roseslive.co.uk! Brought to you by York SU (yorksu.org). Fixture Details: https://roseslive.co.uk/activities/' +
+                  fixture.sport.slug
+                "
+                :location="locationName"
+              />
+            </div>
+            <div class="flex items-center">
+              <a
+                class="flex gap-2 bg-roses-red text-white px-6 md:px-3 py-2 text-center hover:bg-roses-red-dark transition duration-200 ease-in-out scoreTile"
+                alt="See on map"
+                :href="'/map?location=' + fixture.location.id"
+                ><i class="fa-solid fa-location-dot text-2xl"></i
+              ></a>
             </div>
           </div>
         </div>
-        <div class="flex gap-2 lg:w-full justify-end">
-          <div v-if="fixture.startsAt" class="hidden md:flex items-center">
+        <div class="hidden md:flex gap-2 lg:w-full justify-end">
+          <div v-if="fixture.startsAt" class="flex items-center">
             <add-to-calendar
               :start-date="fixture.startsAt"
               :end-date="fixture.endsAt"
@@ -78,7 +141,7 @@
               :location="locationName"
             />
           </div>
-          <div class="hidden md:flex items-center">
+          <div class="flex items-center">
             <a
               class="flex gap-2 bg-roses-red text-white px-6 md:px-3 py-2 text-center hover:bg-roses-red-dark transition duration-200 ease-in-out scoreTile"
               alt="See on map"
@@ -88,35 +151,25 @@
           </div>
         </div>
       </div>
-      <div class="hidden lg:flex items-center justify-end">
+      <div class="hidden xs:flex sm:hidden lg:flex items-center justify-end">
+        <div v-if="York && York.outcome === 'Win'" class="flex flex-grow">
+          <p class="font-bold text-xl">YORK WIN</p>
+        </div>
+        <div
+          v-else-if="Lancaster && Lancaster.outcome === 'Win'"
+          class="flex flex-grow xl:justify-center"
+        >
+          <p class="font-bold text-xl xl:pl-19 text-roses-red">LANCASTER WIN</p>
+        </div>
+        <div v-else-if="York && York.outcome === 'Draw'" class="flex flex-grow">
+          <p class="font-bold text-xl">DRAW</p>
+        </div>
         <p
           v-if="fixture.scoringRules[0].pointsValue !== 0"
-          class="whitespace-nowrap"
+          class="whitespace-nowrap hidden lg:block"
         >
           {{ fixture.scoringRules[0].pointsValue }} POINTS
         </p>
-      </div>
-      <div class="flex md:hidden md:w-full justify-end gap-4">
-        <div v-if="fixture.startsAt" class="">
-          <add-to-calendar
-            :start-date="fixture.startsAt"
-            :end-date="fixture.endsAt"
-            :title="fixture.sport.name + ' - ' + teamName"
-            :description="
-              'Follow all the action live on roseslive.co.uk! Brought to you by York SU (yorksu.org). Fixture Details: https://roseslive.co.uk/activities/' +
-              fixture.sport.slug
-            "
-            :location="locationName"
-          />
-        </div>
-        <div class="flex items-center">
-          <a
-            class="flex gap-2 bg-roses-red text-white px-6 md:px-3 py-2 text-center hover:bg-roses-red-dark transition duration-200 ease-in-out scoreTile"
-            alt="See on map"
-            :href="'/map?location=' + fixture.location.id"
-            ><i class="fa-solid fa-location-dot text-2xl"></i
-          ></a>
-        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Description

This pull request refines the `FixtureTile` component by improving the layout and responsiveness, adding new UI elements for match outcomes, and ensuring better alignment across different screen sizes. The changes enhance the user experience by making the component more intuitive and visually appealing.

### Layout and Responsiveness Improvements:
* Adjusted the `div` class attributes to improve alignment and spacing, such as adding `items-center` and `items-start` for better vertical alignment across screen sizes. (`[[1]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dL16-R16)`, `[[2]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dR29-R64)`, `[[3]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dL68-R109)`)

### Match Outcome Display:
* Introduced new conditional UI elements to display match outcomes ("YORK WIN," "LANCASTER WIN," or "DRAW") based on the `York` and `Lancaster` objects. These elements adapt to different screen sizes for better visibility. (`[[1]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dR29-R64)`, `[[2]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dL68-R109)`, `[[3]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dR154-R174)`)

### Scoring and Calendar Integration:
* Enhanced the display of scoring rules and calendar buttons by adjusting visibility and alignment for different breakpoints (e.g., `hidden`, `flex`, `lg:block`). (`[[1]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dR29-R64)`, `[[2]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dL81-R121)`, `[[3]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dL91-R132)`)
### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
