### PR TITLE
Added draw to results/coverage

### DIFF
--- a/components/LiveReporting.vue
+++ b/components/LiveReporting.vue
@@ -283,10 +283,16 @@
                         York Win
                       </p>
                       <p
-                        v-if="coverage.teams[1].outcome === 'Win'"
+                        v-else-if="coverage.teams[1].outcome === 'Win'"
                         class="xcond font-bold text-3xl text-roses-red"
                       >
                         Lancaster Win
+                      </p>
+                      <p
+                        v-else-if="coverage.teams[0].outcome === 'Draw'"
+                        class="xcond font-bold text-3xl"
+                      >
+                        Draw
                       </p>
                       <p
                         v-if="coverage.scoringRules"
@@ -361,10 +367,16 @@
                     York Win
                   </p>
                   <p
-                    v-if="score.teams[1].outcome === 'Win'"
+                    v-else-if="score.teams[1].outcome === 'Win'"
                     class="xcond font-bold text-3xl text-roses-red"
                   >
                     Lancaster Win
+                  </p>
+                  <p
+                    v-else-if="score.teams[0].outcome === 'Draw'"
+                    class="xcond font-bold text-3xl"
+                  >
+                    Draw
                   </p>
                   <div class="flex flex-col sm:flex-row gap-6 sm:gap-8 w-full">
                     <div class="flex gap-4 items-center">


### PR DESCRIPTION
### Description

This pull request updates the `LiveReporting.vue` component to improve the handling of conditional rendering for match outcomes. The changes ensure that the "Draw" outcome is properly displayed and fix the logic for rendering outcomes when multiple conditions are present.

### Conditional rendering improvements:

* Updated `v-if` to `v-else-if` for the "Lancaster Win" condition to ensure proper evaluation of mutually exclusive outcomes. (`[[1]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7L286-R296)`, `[[2]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7L364-R380)`)
* Added a new `v-else-if` block to handle the "Draw" outcome for both `coverage.teams` and `score.teams`, ensuring it is displayed when applicable. (`[[1]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7L286-R296)`, `[[2]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7L364-R380)`)

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
