### PR TITLE
View venue locations on map, scroll into view, z-index fix

### DIFF
--- a/components/RosesMap.vue
+++ b/components/RosesMap.vue
@@ -162,11 +162,23 @@ export default {
         },
       });
       if (urlLocationId) {
+        this.$nextTick(() => {
+          const mapContainer = document.getElementById("map-container");
+          if (mapContainer) {
+            mapContainer.scrollIntoView({
+              behavior: "smooth",
+              block: "center",
+            });
+          }
+        });
         const locationFeature =
           this.formattedLocations.find(
             (feature) => feature.properties.id === urlLocationId,
           ) ||
           this.formattedChildLocations.find(
+            (feature) => feature.properties.id === urlLocationId,
+          ) ||
+          this.formattedVenues.find(
             (feature) => feature.properties.id === urlLocationId,
           );
 

--- a/components/navbar.vue
+++ b/components/navbar.vue
@@ -45,7 +45,7 @@
     </div>
     <div
       v-if="isMenuOpen"
-      class="lg:hidden absolute top-28 w-full bg-roses-dark"
+      class="lg:hidden absolute top-28 w-full bg-roses-dark z-100"
     >
       <hr class="border-zinc-600 mt-6 mx-6" />
       <div class="container mx-auto flex flex-col gap-10">

--- a/pages/food-and-drink/index.vue
+++ b/pages/food-and-drink/index.vue
@@ -48,11 +48,15 @@
               between fixtures.
             </p>
           </div>
-          <div class="flex">
+          <div class="flex flex-wrap gap-2">
             <RosesButton
               href="https://go.yorksu.org/Yl48o5J"
               target="_blank"
               title="Courtyard"
+            />
+            <RosesButton
+              href="/map?location=cm99unpgi001zpd01eu3xc40y"
+              title="See on map"
             />
           </div>
         </div>
@@ -66,11 +70,15 @@
               alongside a drink.
             </p>
           </div>
-          <div class="flex">
+          <div class="flex flex-wrap gap-2">
             <RosesButton
               href="https://go.yorksu.org/U905BIt"
               target="_blank"
               title="Vanbrugh Arms"
+            />
+            <RosesButton
+              href="/map?location=cm99uwl23003fpd01sfr5ucsa"
+              title="See on map"
             />
           </div>
         </div>
@@ -82,11 +90,15 @@
               fixtures and a bite to eat from YUZU.
             </p>
           </div>
-          <div class="flex">
+          <div class="flex flex-wrap gap-2">
             <RosesButton
               href="https://go.yorksu.org/ikbq4O3"
               target="_blank"
               title="Glasshouse"
+            />
+            <RosesButton
+              href="/map?location=cm7vxotfq002lt301t9811sjw"
+              title="See on map"
             />
           </div>
         </div>
@@ -99,11 +111,15 @@
               and a bagel and relax in our cosy cafe.
             </p>
           </div>
-          <div class="flex">
+          <div class="flex flex-wrap gap-2">
             <RosesButton
               href="https://go.yorksu.org/0ozKisB"
               target="_blank"
               title="Kitchen"
+            />
+            <RosesButton
+              href="/map?location=cm99ux87x003jpd016ga6oufz"
+              title="See on map"
             />
           </div>
         </div>


### PR DESCRIPTION
### Description

This pull request introduces enhancements to the user experience by improving navigation and layout across multiple components. Key changes include adding smooth scrolling to a map component, improving the visibility of the mobile menu, and enhancing the layout and functionality of buttons on the "Food and Drink" page.

### Navigation Improvements:
* [`components/RosesMap.vue`](diffhunk://#diff-09883069380466b34c4e89bd9df2616a3d0c9ab4823c595751bccc41e2882a9eR165-R182): Implemented smooth scrolling to the map container when a location is selected by ID, ensuring a better user experience for navigating the map. Also added support for locating venues in addition to locations and child locations.

### Layout Enhancements:
* [`components/navbar.vue`](diffhunk://#diff-6b7e7b8175dd6130983dc472b3f3ff12268706e1a304a05fb8c286020e81f56aL48-R48): Added a `z-index` value to the mobile menu to ensure it appears above other elements, improving visibility on smaller screens.
* [`pages/food-and-drink/index.vue`](diffhunk://#diff-3dde61e1fe76ed103faea34044b2f87ff219e468c0308d8e4bcd91630e149a1eL51-R60): Updated the layout of buttons by introducing a `flex-wrap` class and a gap between buttons for better alignment and spacing. [[1]](diffhunk://#diff-3dde61e1fe76ed103faea34044b2f87ff219e468c0308d8e4bcd91630e149a1eL51-R60) [[2]](diffhunk://#diff-3dde61e1fe76ed103faea34044b2f87ff219e468c0308d8e4bcd91630e149a1eL69-R82) [[3]](diffhunk://#diff-3dde61e1fe76ed103faea34044b2f87ff219e468c0308d8e4bcd91630e149a1eL85-R102) [[4]](diffhunk://#diff-3dde61e1fe76ed103faea34044b2f87ff219e468c0308d8e4bcd91630e149a1eL102-R123)

### Functional Additions:
* [`pages/food-and-drink/index.vue`](diffhunk://#diff-3dde61e1fe76ed103faea34044b2f87ff219e468c0308d8e4bcd91630e149a1eL51-R60): Added "See on map" buttons for each venue, linking directly to their respective locations on the map for easier navigation. [[1]](diffhunk://#diff-3dde61e1fe76ed103faea34044b2f87ff219e468c0308d8e4bcd91630e149a1eL51-R60) [[2]](diffhunk://#diff-3dde61e1fe76ed103faea34044b2f87ff219e468c0308d8e4bcd91630e149a1eL69-R82) [[3]](diffhunk://#diff-3dde61e1fe76ed103faea34044b2f87ff219e468c0308d8e4bcd91630e149a1eL85-R102) [[4]](diffhunk://#diff-3dde61e1fe76ed103faea34044b2f87ff219e468c0308d8e4bcd91630e149a1eL102-R123)

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
