### PR TITLE
Separated streams by type

### DIFF
--- a/components/LiveReporting.vue
+++ b/components/LiveReporting.vue
@@ -9,26 +9,83 @@
         <h2 class="text-4xl xcond font-bold">
           <span v-if="!catchup">LIVE </span>STREAMS
         </h2>
-        <div class="flex flex-wrap md:flex-col gap-2 w-fit">
-          <button
-            v-for="stream in streams"
-            :key="stream.id"
-            :class="[
-              'bg-roses-red text-white px-6 lg:px-10 py-2 rounded-full text-center hover:cursor-pointer flex flex-row gap-1 md:gap-0 md:flex-col',
-              { '!bg-black !text-white': activeStream.id === stream.id },
-            ]"
-            @click="((activeStream = stream), (accordionOpen = true))"
-          >
-            <p v-if="stream.fixture.sport || stream.fixture.name">
-              <span v-if="stream.fixture.sport"
-                >{{ stream.fixture.sport }}
-              </span>
-              <span v-if="stream.fixture.sport && stream.fixture.name">
-                -
-              </span>
-              <span v-if="stream.fixture.name">{{ stream.fixture.name }}</span>
-            </p>
-          </button>
+        <div v-if="mainStreams.length > 0">
+          <h3 class="font-bold xcond text-2xl">Main Streams</h3>
+          <div class="flex flex-wrap md:flex-col gap-2 w-fit">
+            <button
+              v-for="stream in mainStreams"
+              :key="stream.id"
+              :class="[
+                'bg-roses-red text-white px-6 lg:px-10 py-2 rounded-full text-center hover:cursor-pointer flex flex-row gap-1 md:gap-0 md:flex-col',
+                { '!bg-black !text-white': activeStream.id === stream.id },
+              ]"
+              @click="((activeStream = stream), (accordionOpen = true))"
+            >
+              <p v-if="stream.fixture.sport || stream.fixture.name">
+                <span v-if="stream.fixture.sport"
+                  >{{ stream.fixture.sport }}
+                </span>
+                <span v-if="stream.fixture.sport && stream.fixture.name">
+                  -
+                </span>
+                <span v-if="stream.fixture.name">{{
+                  stream.fixture.name
+                }}</span>
+              </p>
+            </button>
+          </div>
+        </div>
+        <div v-if="video.length > 0">
+          <h3 class="font-bold xcond text-2xl">Video Streams</h3>
+          <div class="flex flex-wrap md:flex-col gap-2 w-fit">
+            <button
+              v-for="stream in video"
+              :key="stream.id"
+              :class="[
+                'bg-roses-red text-white px-6 lg:px-10 py-2 rounded-full text-center hover:cursor-pointer flex flex-row gap-1 md:gap-0 md:flex-col',
+                { '!bg-black !text-white': activeStream.id === stream.id },
+              ]"
+              @click="((activeStream = stream), (accordionOpen = true))"
+            >
+              <p v-if="stream.fixture.sport || stream.fixture.name">
+                <span v-if="stream.fixture.sport"
+                  >{{ stream.fixture.sport }}
+                </span>
+                <span v-if="stream.fixture.sport && stream.fixture.name">
+                  -
+                </span>
+                <span v-if="stream.fixture.name">{{
+                  stream.fixture.name
+                }}</span>
+              </p>
+            </button>
+          </div>
+        </div>
+        <div v-if="radio.length > 0">
+          <h3 class="font-bold xcond text-2xl">Radio Streams</h3>
+          <div class="flex flex-wrap md:flex-col gap-2 w-fit">
+            <button
+              v-for="stream in radio"
+              :key="stream.id"
+              :class="[
+                'bg-roses-red text-white px-6 lg:px-10 py-2 rounded-full text-center hover:cursor-pointer flex flex-row gap-1 md:gap-0 md:flex-col',
+                { '!bg-black !text-white': activeStream.id === stream.id },
+              ]"
+              @click="((activeStream = stream), (accordionOpen = true))"
+            >
+              <p v-if="stream.fixture.sport || stream.fixture.name">
+                <span v-if="stream.fixture.sport"
+                  >{{ stream.fixture.sport }}
+                </span>
+                <span v-if="stream.fixture.sport && stream.fixture.name">
+                  -
+                </span>
+                <span v-if="stream.fixture.name">{{
+                  stream.fixture.name
+                }}</span>
+              </p>
+            </button>
+          </div>
         </div>
       </div>
       <div v-if="!catchup" class="flex flex-col gap-6 order-1 md:order-2">
@@ -624,6 +681,8 @@ export default {
     return {
       blogs: [],
       streams: [],
+      video: [],
+      radio: [],
       mainStreams: [],
       photos: [],
       scores: [],
@@ -682,8 +741,16 @@ export default {
         content: this.extractVideoId(stream.content),
         coverage: stream.coverage,
       }));
-      if (this.streams.length > 0 && this.catchup) {
-        this.activeStream = this.streams[0];
+      this.video = this.streams.filter(
+        (stream) => stream.coverage === "TVCoverage",
+      );
+      this.radio = this.streams.filter(
+        (stream) => stream.coverage === "RadioCoverage",
+      );
+      if (this.video.length > 0 && this.catchup) {
+        this.activeStream = this.video[0];
+      } else if (this.radio.length > 0 && this.catchup) {
+        this.activeStream = this.radio[0];
       }
       if (!this.catchup) {
         const mainStreamsResponse = await $fetch(
@@ -701,17 +768,6 @@ export default {
           coverage: stream.coverage,
         }));
 
-        // Add main streams to the beginning of the streams array
-        this.streams = [
-          ...this.mainStreams,
-          ...this.streams.filter(
-            (stream) =>
-              !this.mainStreams.some(
-                (mainStream) => mainStream.id === stream.id,
-              ),
-          ),
-        ];
-
         const rosesTrailer = {
           id: "roseTrailer",
           fixture: {
@@ -720,8 +776,12 @@ export default {
           content: "S_F-QjAy2Rg",
           coverage: "TVCoverage",
         };
-        this.streams.unshift(rosesTrailer);
-        this.activeStream = rosesTrailer;
+        this.video.unshift(rosesTrailer);
+        if (this.mainStreams.length > 0) {
+          this.activeStream = this.mainStreams[0];
+        } else {
+          this.activeStream = rosesTrailer;
+        }
       }
     },
     async getBlogs() {


### PR DESCRIPTION
### Description

This pull request refactors the `LiveReporting.vue` component to improve the organization of streams by categorizing them into `Main Streams`, `Video Streams`, and `Radio Streams`. It also simplifies the logic for setting the active stream and updates the UI to reflect these changes.

### UI Enhancements:
* Added separate sections in the UI to display `Main Streams`, `Video Streams`, and `Radio Streams`, each with its own heading and buttons for selection. [[1]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7R12-R16) [[2]](diffhunk://#diff-319fdf620485b8ca6fccff5cde8cb651f9fb4a7decd7cd2de091d8f786fed3d7L29-R90)

### Data Organization:
* Introduced new arrays (`video` and `radio`) to categorize streams based on their coverage type (`TVCoverage` for video and `RadioCoverage` for radio).
* Updated logic to filter streams into the new categories and set the initial active stream based on the available streams.

### Code Simplification:
* Removed the logic that merged `mainStreams` into the `streams` array, as streams are now handled in separate categories.
* Adjusted the handling of the `rosesTrailer` stream to prepend it to the `video` array instead of the `streams` array.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
