### PR TITLE
Added search by location to map

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "vue-select/dist/vue-select.css";
 
 @theme {
   --font-*: initial;
@@ -260,4 +261,29 @@ body .xcond {
 
 .banner-container {
   @apply w-full max-w-screen-2xl;
+}
+
+/* Vue-Select */
+.vs__dropdown-menu {
+  @apply bg-light-gray;
+}
+
+.vs__dropdown-menu::-webkit-scrollbar {
+  @apply w-2;
+}
+
+.vs__dropdown-menu::-webkit-scrollbar-track {
+  @apply w-4;
+}
+
+.vs__dropdown-menu::-webkit-scrollbar-thumb {
+  @apply bg-roses-red rounded-lg;
+}
+
+.vs__dropdown-menu::-webkit-scrollbar-thumb:hover {
+  @apply bg-roses-red-dark;
+}
+
+.vs__dropdown-option--highlight {
+  @apply text-roses-red font-semibold bg-gray-100;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "tiny-cookie": "^2.5.1",
         "vue": "latest",
         "vue-router": "latest",
+        "vue-select": "^4.0.0-beta.6",
         "vue-tsc": "^2.2.0"
       },
       "devDependencies": {
@@ -18681,6 +18682,15 @@
       },
       "peerDependencies": {
         "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vue-select": {
+      "version": "4.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/vue-select/-/vue-select-4.0.0-beta.6.tgz",
+      "integrity": "sha512-K+zrNBSpwMPhAxYLTCl56gaMrWZGgayoWCLqe5rWwkB8aUbAUh7u6sXjIR7v4ckp2WKC7zEEUY27g6h1MRsIHw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "3.x"
       }
     },
     "node_modules/vue-tsc": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "tiny-cookie": "^2.5.1",
     "vue": "latest",
     "vue-router": "latest",
+    "vue-select": "^4.0.0-beta.6",
     "vue-tsc": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

This pull request introduces a Vue-Select dropdown to the `RosesMap` component, allowing users to search and select locations. It also includes styling and functionality changes to support this feature. The most important changes are grouped into the following themes:

### Integration of Vue-Select:

* Added `vue-select` as a dependency in `package.json` to enable the use of Vue-Select components.
* Imported `vue-select` in `RosesMap.vue` and registered it as a component. Added a Vue-Select dropdown in the template to allow users to search and select locations. [[1]](diffhunk://#diff-09883069380466b34c4e89bd9df2616a3d0c9ab4823c595751bccc41e2882a9eR2-R20) [[2]](diffhunk://#diff-09883069380466b34c4e89bd9df2616a3d0c9ab4823c595751bccc41e2882a9eR33-R40)

### Styling for Vue-Select:

* Updated `main.css` to include Vue-Select styles by importing `vue-select/dist/vue-select.css`. Added custom styles for the dropdown menu and scrollbar to match the application's theme. [[1]](diffhunk://#diff-b15932692c619f9a334ecb156ac167557c3af214a8a3df8990c09232ac8a5baaR2) [[2]](diffhunk://#diff-b15932692c619f9a334ecb156ac167557c3af214a8a3df8990c09232ac8a5baaR265-R289)

### Location Selection Functionality:

* Added a `selectedLocation` data property and a `selectLocation` method in `RosesMap.vue`. The method updates the map view and active location based on the selected location from the dropdown. [[1]](diffhunk://#diff-09883069380466b34c4e89bd9df2616a3d0c9ab4823c595751bccc41e2882a9eR33-R40) [[2]](diffhunk://#diff-09883069380466b34c4e89bd9df2616a3d0c9ab4823c595751bccc41e2882a9eR476-R502)
* Implemented a watcher for `selectedLocation` to trigger the `selectLocation` method whenever the dropdown value changes.

### Additional Enhancements:

* Sorted locations alphabetically by name in the `getLocations` method to improve the user experience when browsing the dropdown options.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
