### PR TITLE
Added forfeiting logic

### DIFF
--- a/components/FixtureTile.vue
+++ b/components/FixtureTile.vue
@@ -47,6 +47,20 @@
           >
             <p class="font-bold text-xl">DRAW</p>
           </div>
+          <div
+            v-else-if="York && York.outcome === 'Forfeit'"
+            class="flex pr-10 md:pr-58"
+          >
+            <p class="font-bold text-xl">YORK FORFEIT</p>
+          </div>
+          <div
+            v-else-if="Lancaster && Lancaster.outcome === 'Forfeit'"
+            class="flex pr-10"
+          >
+            <p class="font-bold text-xl xl:pl-19 text-roses-red">
+              LANCASTER FORFEIT
+            </p>
+          </div>
         </div>
         <p
           v-if="fixture.scoringRules[0].pointsValue > 0"
@@ -110,6 +124,20 @@
               >
                 <p class="font-bold text-xl">DRAW</p>
               </div>
+              <div
+                v-else-if="York && York.outcome === 'Forfeit'"
+                class="flex flex-grow"
+              >
+                <p class="font-bold text-xl">YORK FORFEIT</p>
+              </div>
+              <div
+                v-else-if="Lancaster && Lancaster.outcome === 'Forfeit'"
+                class="flex flex-grow xl:justify-center"
+              >
+                <p class="font-bold text-xl text-roses-red">
+                  LANCASTER FORFEIT
+                </p>
+              </div>
             </div>
             <div v-if="fixture.startsAt" class="">
               <add-to-calendar
@@ -168,6 +196,20 @@
         </div>
         <div v-else-if="York && York.outcome === 'Draw'" class="flex flex-grow">
           <p class="font-bold text-xl">DRAW</p>
+        </div>
+        <div
+          v-else-if="York && York.outcome === 'Forfeit'"
+          class="flex flex-grow"
+        >
+          <p class="font-bold text-xl">YORK FORFEIT</p>
+        </div>
+        <div
+          v-else-if="Lancaster && Lancaster.outcome === 'Forfeit'"
+          class="flex flex-grow xl:justify-center"
+        >
+          <p class="font-bold text-xl xl:pl-19 text-roses-red">
+            LANCASTER FORFEIT
+          </p>
         </div>
         <p
           v-if="fixture.scoringRules[0].pointsValue > 0"

--- a/components/LiveReportingResultTile.vue
+++ b/components/LiveReportingResultTile.vue
@@ -30,6 +30,18 @@
           Draw
         </p>
         <p
+          v-else-if="coverage.teams[0].outcome === 'Forfeit'"
+          class="xcond font-bold text-3xl"
+        >
+          York Forfeit
+        </p>
+        <p
+          v-else-if="coverage.teams[1].outcome === 'Forfeit'"
+          class="xcond font-bold text-3xl text-roses-red"
+        >
+          Lancaster Forfeit
+        </p>
+        <p
           v-if="coverage.scoringRules[0].pointsValue > 0"
           class="text-lg font-semibold"
         >


### PR DESCRIPTION
### Description

This pull request introduces changes to handle and display "Forfeit" outcomes for the York and Lancaster teams in the `FixtureTile` and `LiveReportingResultTile` components. The updates ensure that forfeits are visually distinct and consistent with existing styles for other outcomes like "Draw."

### Updates to `FixtureTile.vue`:

* Added conditional blocks to check if York or Lancaster has a "Forfeit" outcome and display corresponding messages ("YORK FORFEIT" or "LANCASTER FORFEIT") with appropriate styling. These changes were applied in three different sections of the file to cover all relevant scenarios. [[1]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dR50-R63) [[2]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dR127-R140) [[3]](diffhunk://#diff-e60346bcf3c45a2565314d0c12cab591b7680f88e7339cc594feb88731c9b27dR200-R213)

### Updates to `LiveReportingResultTile.vue`:

* Added conditional blocks to handle "Forfeit" outcomes for York and Lancaster, displaying "York Forfeit" or "Lancaster Forfeit" in bold text with styling consistent with the component's design.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
