### PR TITLE
feat: distinguish between radio and tv main streams

### DIFF
--- a/components/LiveReporting.vue
+++ b/components/LiveReporting.vue
@@ -33,6 +33,10 @@
                 <span v-if="stream.fixture.name">{{
                   stream.fixture.name
                 }}</span>
+                <span v-if="stream.coverage === 'TVCoverage'"> (TV) </span>
+                <span v-if="stream.coverage === 'RadioCoverage'">
+                  (Radio)
+                </span>
               </p>
             </button>
           </div>


### PR DESCRIPTION
### Description

Labels the main streams with either (TV) or (Radio), since they're sharing a fixture and currently it's not clear which is which

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [ ] A GitHub issue or linear task is linked to this pull request.
